### PR TITLE
Fix dependency validation bug

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -368,7 +368,6 @@ def _generate_hub_and_spokes(
                               "and file a bug at https://github.com/dzbarsky/rules_rs/issues/new") % (
                             package["name"], dep_name, req, locked_version
                         ))
-                    continue
 
             features = dep["features"]
             if dep["uses_default_features"]:


### PR DESCRIPTION
When using validate_lockfile = True, I was hitting:

```
ERROR: /private/var/tmp/_bazel/1e8b9af476839e9c283f147eb1b9fe65/external/rules_rs+/rs/extensions.bzl:649:94: Traceback (most recent call last):
	File "/private/var/tmp/_bazel/1e8b9af476839e9c283f147eb1b9fe65/external/rules_rs+/rs/extensions.bzl", line 826, column 46, in _crate_impl
		facts |= _generate_hub_and_spokes(mctx, cfg.name, annotations, cargo_path, cfg.cargo_lock, hub_packages, sparse_registry_configs, cfg.platform_triples, cargo_credentials, cfg.cargo_config, cfg.validate_lockfile, cfg.debug)
	File "/private/var/tmp/_bazel/1e8b9af476839e9c283f147eb1b9fe65/external/rules_rs+/rs/extensions.bzl", line 649, column 94, in _generate_hub_and_spokes
		bazel_target = "//" + paths.join(cargo_lock_path.package, _normalize_path(dep["path"]).removeprefix(repo_root + "/"))
Error: key "path" not found in dictionary
```

The continue was mistakenly skipping the rest of the loop and never setting `bazel_target`. I validated that this fix restores the expected behavior.