### PR TITLE
Fix `features2` update in some cases

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -273,7 +273,9 @@ def _generate_hub_and_spokes(
 
                     # Crates published with newer Cargo populate this field for `resolver = "2"`.
                     # It can express more nuanced feature dependencies and overrides the keys from legacy features, if present.
-                    features.update(metadata.get("features2", {}))
+                    features2_meta = metadata.get("features2")
+                    if features2_meta:
+                        features.update(features2_meta)
 
                     dependencies = metadata["deps"]
 


### PR DESCRIPTION
`features2` key could be present but its value `None`. Leading to :
```
ERROR: /<path_to_cache>/aa71b1dc3fd25eda1f9f28ad27b5446f/external/rules_rs+/rs/extensions.bzl:276:36: Traceback (most recent call last):
	File "/<path_to_cache>/aa71b1dc3fd25eda1f9f28ad27b5446f/external/rules_rs+/rs/extensions.bzl", line 991, column 46, in _crate_impl
		facts |= _generate_hub_and_spokes(mctx, cfg.name, annotations, cargo_path, cfg.cargo_lock, cargo_toml_by_hub_name[cfg.name], hub_packages, sparse_registry_configs, cfg.platform_triples, cargo_credentials, cfg.cargo_config, cfg.validate_lockfile, cfg.debug)
	File "/<path_to_cache>/aa71b1dc3fd25eda1f9f28ad27b5446f/external/rules_rs+/rs/extensions.bzl", line 276, column 36, in _generate_hub_and_spokes
		features.update(metadata.get("features2", {}))
Error in update: in update, got NoneType, want iterable
```