### PR TITLE
Allow dev_deps to be restricted to cargo only

### DIFF
--- a/rs/private/all_crate_deps.bzl
+++ b/rs/private/all_crate_deps.bzl
@@ -1,9 +1,6 @@
 load(":rust_deps.bzl", _rust_deps = "rust_deps")
 
-def filter_by_prefix(deps, prefix):
-    if not prefix:
-        return deps
-
+def _filter_by_prefix(deps, prefix):
     return [dep for dep in deps if dep.startswith(prefix)]
 
 def rust_deps(name, **kwargs):
@@ -50,9 +47,9 @@ def all_crate_deps(
     dev_deps = dep_data["dev_deps"]
 
     if filter_prefix:
-        deps = filter_by_prefix(deps, filter_prefix)
-        build_deps = filter_by_prefix(build_deps, filter_prefix)
-        dev_deps = filter_by_prefix(dev_deps, filter_prefix)
+        deps = _filter_by_prefix(deps, filter_prefix)
+        build_deps = _filter_by_prefix(build_deps, filter_prefix)
+        dev_deps = _filter_by_prefix(dev_deps, filter_prefix)
 
     if normal_dev:
         rust_deps(


### PR DESCRIPTION
Now that dev_deps are supported we want the same as in https://github.com/dzbarsky/rules_rs/commit/4f6ef70ccce6b8f2c96ceb64e1b0e936de843314 for dev_deps