### PR TITLE
Suppress spurious version resolution warning for optional deps

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -413,6 +413,7 @@ def _generate_hub_and_spokes(
         feature_resolutions_by_fq_crate[_fq_crate(name, version)] = feature_resolutions
 
     for package in packages:
+        name = package["name"]
         deps_by_name = {}
         for maybe_fq_dep in package.get("dependencies", []):
             idx = maybe_fq_dep.find(" ")
@@ -441,7 +442,8 @@ def _generate_hub_and_spokes(
                 else:
                     resolved_version = select_matching_version(dep["req"], versions)
                     if not resolved_version:
-                        print(name, dep_package, versions, dep["req"])
+                        if not dep.get("optional"):
+                            print("WARNING: %s: could not resolve %s %s among %s" % (name, dep_package, dep["req"], versions))
                         continue
 
             dep_fq = _fq_crate(dep_package, resolved_version)


### PR DESCRIPTION
## Summary

- Fix stale `name` variable in warning print — it referenced the last package from a previous loop, not the package with the unresolvable dep
- Only print a warning when version resolution fails for **non-optional** deps, which indicates a genuine problem
- Skip the warning for optional deps behind disabled feature flags, since failing to resolve is expected behavior

## Context

During version resolution, the code iterates all `possible_deps` (including optional ones) and attempts to resolve each dep's version against the lockfile. When an optional dependency's version requirement doesn't match any version in the lockfile, this is expected — the dep is behind a disabled feature flag and no crate in the workspace actually uses it at that version.

For example, `serde_with 3.14.0` has three optional renamed deps on `schemars` at different versions ([source](https://github.com/jonasbb/serde_with/blob/v3.14.0/serde_with/Cargo.toml)):

```toml
schemars_0_8 = { package = "schemars", version = "0.8.16", optional = true, default-features = false }
schemars_0_9 = { package = "schemars", version = "0.9.0", optional = true, default-features = false }
schemars_1   = { package = "schemars", version = "1.0.2", optional = true, default-features = false }
```

If the lockfile only contains `schemars` at versions `0.9.0` and `1.0.3` (used by other crates), the `schemars_0_8` dep's `^0.8.16` req correctly fails to resolve since `^0.8.16` means `>=0.8.16, <0.9.0`. Due to the stale `name` variable, this produced the misleading message:

```
DEBUG: .../extensions.bzl: zstd-sys schemars ["0.9.0", "1.0.3"] ^0.8.16
```

The `name` variable was set in a previous loop (line 254) and never reassigned in the version resolution loop (line 415), so it always printed the last package from the first loop. With the name variable fix alone, the correct message would be:

```
WARNING: serde_with: could not resolve schemars ^0.8.16 among ["0.9.0", "1.0.3"]
```

But since this dep is optional and not enabled by any feature, it's not actionable. The existing `continue` already handles it correctly (the dep never gets a `bazel_target`, so the resolver skips it, and the post-resolution validation would `fail()` if any feature tried to activate it). So we suppress the warning for optional deps entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)