### PR TITLE
Add 3rd party annotation for apriltag

### DIFF
--- a/3rd_party/apriltag-sys/include.MODULE.bazel
+++ b/3rd_party/apriltag-sys/include.MODULE.bazel
@@ -1,0 +1,27 @@
+crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")
+crate.annotation(
+    additive_build_file_content = """
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "apriltags",
+    srcs = glob(
+        [
+            "apriltag-src/*.c",
+            "apriltag-src/*.h",
+            "apriltag-src/common/*.c",
+            "apriltag-src/common/*.h",
+        ],
+        exclude = [
+            "apriltag-src/apriltag_pywrap.c",
+        ],
+    ),
+    includes = ["apriltag-src"],
+)""",
+    crate = "apriltag-sys",
+    gen_build_script = "off",
+    repositories = ["crates"],
+    deps = [
+        ":apriltags",
+    ],
+)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -40,6 +40,7 @@ rust_binary(
     srcs = ["main.rs"],
     deps = [
         "@many_workspace_deps//:actix-web",
+        "@many_workspace_deps//:apriltag",
         "@many_workspace_deps//:apple-codesign",
         "@many_workspace_deps//:axum",
         "@many_workspace_deps//:ballista",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -164,6 +164,7 @@ crate.annotation(
 include("//:3rd_party/bzip2-sys/include.MODULE.bazel")
 include("//:3rd_party/glib-sys/include.MODULE.bazel")
 include("//:3rd_party/lzma-sys/include.MODULE.bazel")
+include("//:3rd_party/apriltag-sys/include.MODULE.bazel")
 include("//:3rd_party/zstd-sys/include.MODULE.bazel")
 
 # TODO(zbarsky): alsa-sys is not curently tested, fix it

--- a/test/many_workspace_deps/Cargo.toml
+++ b/test/many_workspace_deps/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dependencies]
 actix-web = "4.11.0"
+apriltag = "0.4.0"
 apple-codesign = "0.27.0"
 axum = "0.8.4"
 #bevy = "0.16.1"


### PR DESCRIPTION
Don't use the build.rs file to compile apriltag C/C++ code. The build file content added uses https://github.com/jerry73204/apriltag-rust/tree/master/apriltag-sys. In theory we could also solve this with https://registry.bazel.build/modules/apriltag which is exactly the same version for the lastest master. But the current way should be more robust as it will use exactly the version that  it shipped with the current apriltag version.