### PR TITLE
Add JetBrains link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ See https://registry.bazel.build/docs/rules_rs
 - [Datadog Agent](https://github.com/DataDog/datadog-agent)
 - [ZML](https://github.com/zml/zml/tree/zml/v2)
 - [rules_py](https://github.com/aspect-build/rules_py)
+- [JetBrains](https://github.com/JetBrains/intellij-community), used in closed sources of [JetBrains Air](https://air.dev/) especially
 
 ## Telemetry & privacy policy
 


### PR DESCRIPTION
For now the link points to a Bazel module that does not use it, but it's the actual repo using it internally (just in the closed sources part of it). Eventually anyway we will use these rules in the community part as well.