### PR TITLE
Fix `strip_values` value getter

### DIFF
--- a/rs/experimental/rules_rust.bzl
+++ b/rs/experimental/rules_rust.bzl
@@ -27,7 +27,7 @@ def _rules_rust_impl(mctx):
     if len(strip_values) > 1:
         fail("Found conflicting strip values in rules_rust.patch tags")
 
-    strip = list(strip_values)()[0] if strip_values else 0
+    strip = list(strip_values)[0] if strip_values else 0
 
     http_archive(
         name = "rules_rust",


### PR DESCRIPTION
```
ERROR: /Users/titouan.bion/Library/Caches/JetBrains/MonorepoBazel/aa71b1dc3fd25eda1f9f28ad27b5446f/external/rules_rs+/rs/experimental/rules_rust.bzl:30:31: Traceback (most recent call last):
	File "/Users/titouan.bion/Library/Caches/JetBrains/MonorepoBazel/aa71b1dc3fd25eda1f9f28ad27b5446f/external/rules_rs+/rs/experimental/rules_rust.bzl", line 30, column 31, in _rules_rust_impl
		strip = list(strip_values)()[0] if strip_values else 0
Error: 'list' object is not callable
```