### PR TITLE
fix: handle missing 'path' key in dependency resolution

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -992,7 +992,11 @@ RESOLVED_PLATFORMS = select({{
         for dep in package["dependencies"]:
             bazel_target = dep.get("bazel_target")
             if not bazel_target:
-                bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep["path"]).removeprefix(repo_root + "/"))
+                dep_path = dep.get("path")
+                if not dep_path:
+                    # Registry crate without a path — handled via the crate hub, skip.
+                    continue
+                bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep_path).removeprefix(repo_root + "/"))
 
             if dep.get("rename"):
                 aliases[bazel_target] = dep["rename"].replace("-", "_")


### PR DESCRIPTION
## Summary

In `_generate_hub_and_spokes`, the code iterates over workspace package dependency lists and assumes that all deps without a `bazel_target` have a `path` key. However, workspace members can depend on registry crates (from crates.io), and these dependencies only have a `source` key in cargo metadata output — no `path`. This causes a `KeyError` at runtime.

## Root Cause

When `cargo metadata --no-deps` is run, workspace member packages list all their dependencies. Registry crate dependencies appear in this list without a `path` key. The existing code at line 995 does:

```starlark
bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep["path"]).removeprefix(repo_root + "/"))
```

This unconditionally accesses `dep["path"]`, which fails for registry deps.

## Fix

Check for the `path` key before using it. If a dependency doesn't have a `path`, it's a registry crate that will be resolved via the crate hub, so we skip it with `continue`.

## Testing

Tested with a workspace that has members depending on both path dependencies and registry crates (e.g., `serde`, `tokio`). Before this fix, the module extension fails with a `KeyError`. After this fix, it correctly skips registry deps and resolves them through the crate hub.