### PR TITLE
perf: pre-filter JSONL lines before json.decode

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -379,7 +379,10 @@ def _generate_hub_and_spokes(
 
                 # TODO(zbarsky): Should we also dedupe this parsing?
                 metadatas = mctx.read(name + ".jsonl").strip().split("\n")
+                version_needle = '"vers":"%s"' % version
                 for metadata in metadatas:
+                    if version_needle not in metadata:
+                        continue
                     metadata = json.decode(metadata)
                     if metadata["vers"] != version:
                         continue


### PR DESCRIPTION
## Summary

When scanning crate index JSONL files for a specific version, the current code calls `json.decode()` on every line and then checks if the version matches. For crates with many published versions, this is wasteful.

## Motivation

Popular crates like `serde` (250+ versions), `syn` (200+ versions), `tokio`, `rand`, etc. have JSONL index files with hundreds of lines. On a cold build (no facts cache), the module extension parses every single JSON object just to find the one matching version. In Starlark, `json.decode()` is relatively expensive since it allocates new dictionaries, lists, and strings for every parsed object.

## Fix

Add a string pre-filter before `json.decode()`:

```starlark
version_needle = '"vers":"%s"' % version
for metadata in metadatas:
    if version_needle not in metadata:
        continue
    metadata = json.decode(metadata)
```

Since each JSONL line is a single JSON object on one line, checking for the version string as a substring is a reliable pre-filter. The subsequent `json.decode()` + version comparison still acts as the authoritative check, so there are no correctness concerns even if the string pre-filter has false positives.

## Impact

- For crates with 100+ versions: avoids ~90% of JSON parsing
- For crates with <10 versions: negligible overhead (one string `in` check per line)
- Only affects cold builds — the facts cache makes subsequent builds instant regardless
- No behavioral change — the authoritative `metadata["vers"] != version` check is still performed after decoding

## Testing

Benchmarked with a workspace depending on serde, syn, tokio, rand, and other high-version-count crates. Cold build module extension evaluation time decreased measurably.