### PR TITLE
fix: skip mctx.facts cache for path-dep crates

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -412,36 +412,37 @@ def _generate_hub_and_spokes(
                     # Nest a serialized JSON since max path depth is 5.
                     facts[key] = json.encode(fact)
         elif source.startswith("path+"):
+            # Always re-read path-dep Cargo.toml instead of using cached facts.
+            # Path deps are local (fast to read), and their Cargo.toml can change
+            # features/deps without changing the facts key, causing stale resolution.
+            # Also watch the file so Bazel re-runs the extension when it changes.
             key = source + "_" + name
-            fact = existing_facts.get(key)
-            if fact:
-                facts[key] = fact
-                fact = json.decode(fact)
-            else:
-                annotation = annotation_for(annotations, name, package["version"])
-                cargo_toml_json = run_toml2json(mctx, paths.join(package["local_path"], "Cargo.toml"))
+            cargo_toml_path = paths.join(package["local_path"], "Cargo.toml")
+            mctx.watch(mctx.path(cargo_toml_path))
+            annotation = annotation_for(annotations, name, package["version"])
+            cargo_toml_json = run_toml2json(mctx, cargo_toml_path)
 
-                dependencies = [
-                    _spec_to_dep_dict(dep, spec, annotation, {})
-                    for dep, spec in cargo_toml_json.get("dependencies", {}).items()
-                ] + [
-                    _spec_to_dep_dict(dep, spec, annotation, {}, is_build = True)
-                    for dep, spec in cargo_toml_json.get("build-dependencies", {}).items()
-                ]
+            dependencies = [
+                _spec_to_dep_dict(dep, spec, annotation, {})
+                for dep, spec in cargo_toml_json.get("dependencies", {}).items()
+            ] + [
+                _spec_to_dep_dict(dep, spec, annotation, {}, is_build = True)
+                for dep, spec in cargo_toml_json.get("build-dependencies", {}).items()
+            ]
 
-                for target, value in cargo_toml_json.get("target", {}).items():
-                    for dep, spec in value.get("dependencies", {}).items():
-                        converted = _spec_to_dep_dict(dep, spec, annotation, {})
-                        converted["target"] = target
-                        dependencies.append(converted)
+            for target, value in cargo_toml_json.get("target", {}).items():
+                for dep, spec in value.get("dependencies", {}).items():
+                    converted = _spec_to_dep_dict(dep, spec, annotation, {})
+                    converted["target"] = target
+                    dependencies.append(converted)
 
-                fact = dict(
-                    features = cargo_toml_json.get("features", {}),
-                    dependencies = dependencies,
-                    strip_prefix = "",
-                )
+            fact = dict(
+                features = cargo_toml_json.get("features", {}),
+                dependencies = dependencies,
+                strip_prefix = "",
+            )
 
-                facts[key] = json.encode(fact)
+            facts[key] = json.encode(fact)
             package["strip_prefix"] = fact.get("strip_prefix", "")
         elif source.startswith("git+"):
             key = source + "_" + name


### PR DESCRIPTION
## Summary

The `mctx.facts` cache causes stale feature and dependency resolution for path-dep crates when their `Cargo.toml` is modified.

## Root Cause

`mctx.facts` persists across `bazel clean --expunge` (it is stored in the module extension lockfile / repo cache, separate from the output base). For path-dep crates, the facts key is `source + "_" + name`, where `source` is something like `path+hub_name/rel/path`. This key does **not** change when the crate's `Cargo.toml` content changes.

This means that if you:
1. Build successfully (facts are cached)
2. Modify a vendored/path-dep crate's `Cargo.toml` (e.g., add features, optional dependencies, or build-dependencies)
3. Build again

...the module extension uses the stale cached facts from step 1, producing incorrect feature resolution and dependency graphs. Even `bazel clean --expunge` does not fix this because `mctx.facts` survives it.

## Fix

1. **Skip the facts cache for path-dep crates**: Always re-read their `Cargo.toml` via `run_toml2json`. This is safe because path-dep crates are local files (~10ms to read), unlike registry crates (which require network access) or git crates (which require checkout). The performance impact is negligible.

2. **Add `mctx.watch()` on path-dep `Cargo.toml` files**: This ensures Bazel automatically re-evaluates the module extension when any path-dep `Cargo.toml` changes, providing correct incremental behavior.

Registry (`sparse+`) and git (`git+`) crate facts are still cached, since their content is immutable for a given version/commit.

## Testing

Reproduced the bug by:
1. Building with a vendored crate that has no `[features]` section
2. Adding a `[features]` section to the vendored crate's `Cargo.toml`
3. Building again — before the fix, stale `features = {}` was used; after the fix, the new features are correctly resolved