### PR TITLE
fix: add skip_per_crate_rustc_flags to rust_crate.bzl

### DIFF
--- a/rs/rust_crate.bzl
+++ b/rs/rust_crate.bzl
@@ -150,6 +150,7 @@ def rust_crate(
         target_compatible_with = target_compatible_with,
         package_metadata = [name + "_package_metadata"],
         visibility = ["//visibility:public"],
+        skip_per_crate_rustc_flags = True,
     )
 
     if is_proc_macro:


### PR DESCRIPTION
## Summary

Set `skip_per_crate_rustc_flags = True` on crates generated by rules_rs, enabling Bazel configuration trimming for third-party crates.

## Motivation

`rules_rust` supports `per_crate_rustc_flags` which allows users to set different rustc flags for different crates (typically first-party crates). However, without `skip_per_crate_rustc_flags = True`, every third-party crate participates in the configuration transition for per-crate flags.

This means that any change to `per_crate_rustc_flags` — even one targeting only first-party code — causes Bazel to re-analyze and potentially rebuild **all** third-party crates. In workspaces with hundreds of transitive dependencies, this can add significant time to incremental builds.

## Fix

Add `skip_per_crate_rustc_flags = True` to the `rust_library` / `rust_proc_macro` kwargs in `rust_crate.bzl`. This tells `rules_rust` that these crates should not be affected by per-crate rustc flag changes, allowing Bazel to trim this configuration dimension and avoid unnecessary rebuilds.

This is safe because:
- Third-party crates already have `--cap-lints=allow` set
- Users who need custom flags for specific third-party crates can use annotations to override this
- The flag only affects configuration trimming, not the actual compilation flags applied

## Testing

Tested by modifying `per_crate_rustc_flags` in a workspace with 200+ third-party crates. Before this change, all third-party crates were re-analyzed. After this change, only the targeted first-party crates are re-analyzed.