### PR TITLE
Fix cross-output-base symlink breakage in crate_git_repository

### DIFF
--- a/rs/private/crate_git_repository.bzl
+++ b/rs/private/crate_git_repository.bzl
@@ -1,3 +1,5 @@
+"""Repository rule for git-sourced crates with strip_prefix support."""
+
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load(":repository_utils.bzl", "common_attrs", "generate_build_file")
 load(":toml2json.bzl", "run_toml2json")
@@ -32,7 +34,7 @@ def _crate_git_repository_implementation(rctx):
         "--force",
         "--force",
         "--detach",
-        "HEAD"
+        "HEAD",
     ])
     if result.return_code != 0:
         fail(result.stderr)
@@ -42,7 +44,18 @@ def _crate_git_repository_implementation(rctx):
         if not dest_link.exists:
             fail("strip_prefix at {} does not exist in repo".format(strip_prefix))
         for item in dest_link.readdir():
-            rctx.symlink(item, root.get_child(item.basename))
+            # Use relative symlinks so the repo remains valid when served from
+            # Bazel's repository_cache to a different output base.  Absolute
+            # symlinks (what rctx.symlink produces) embed the original output
+            # base path and break on reuse.
+            ln_result = rctx.execute([
+                "ln",
+                "-sf",
+                ".tmp_git_root/" + strip_prefix + "/" + item.basename,
+                str(root.get_child(item.basename)),
+            ])
+            if ln_result.return_code != 0:
+                fail("symlink failed for {}: {}".format(item.basename, ln_result.stderr))
 
     patch(rctx)
 


### PR DESCRIPTION
## Problem

`crate_git_repository` uses `rctx.symlink()` to link files from a `strip_prefix` subdirectory to the repository root. However, `rctx.symlink()` creates **absolute symlinks** that embed the full output base path (e.g., `/home/user/.cache/bazel/_bazel_user/<hash>/external/...`).

When Bazel's `--repository_cache` serves a cached repository to a build running with a **different** `--output_base`, these absolute symlinks point to non-existent paths, causing `No such file or directory` errors for all `strip_prefix` crates.

### When does this happen?

This commonly occurs in CI setups (or local development workflows) where different build configurations use separate `--output_base` directories to maintain independent action caches while sharing a common `--repository_cache`. For example:

```bash
# Different configs, different output bases, shared repo cache
bazel --output_base=~/cache/test test //...
bazel --output_base=~/cache/asan test //... --config=asan
bazel --output_base=~/cache/tsan test //... --config=tsan
```

The first invocation populates the repository cache with absolute symlinks pointing into its output base. Subsequent invocations with different output bases find those cached repositories, but the symlinks are broken because they point to the first output base's paths.

## Solution

Replace `rctx.symlink()` with explicit `ln -sf` using **relative** paths (`.tmp_git_root/<prefix>/<basename>`). Relative symlinks remain valid regardless of which output base the repository is served from, since they resolve relative to the symlink's own location.

### Before (broken across output bases)
```
repo_root/some_file -> /home/user/.cache/bazel/_bazel_user/abc123/external/.tmp_git_root/prefix/some_file
```

### After (works across output bases)
```
repo_root/some_file -> .tmp_git_root/prefix/some_file
```

## Testing

Verified that builds using separate `--output_base` directories with a shared `--repository_cache` no longer fail with broken symlinks for `strip_prefix` crates.