### PR TITLE
fix: handle missing 'path' key in dependency resolution

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -992,7 +992,11 @@ RESOLVED_PLATFORMS = select({{
         for dep in package["dependencies"]:
             bazel_target = dep.get("bazel_target")
             if not bazel_target:
-                bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep["path"]).removeprefix(repo_root + "/"))
+                dep_path = dep.get("path")
+                if not dep_path:
+                    # Registry crate without a path — handled via the crate hub, skip.
+                    continue
+                bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep_path).removeprefix(repo_root + "/"))
 
             if dep.get("rename"):
                 aliases[bazel_target] = dep["rename"].replace("-", "_")


### PR DESCRIPTION
## Summary

Registry deps in workspace package dependency lists may lack a `path` key — they only have `source`. The extension code in `_generate_hub_and_spokes` assumed all deps without a `bazel_target` have a `path`, causing `KeyError` when processing workspace packages that include registry dependencies.

## Problem

When a workspace `Cargo.toml` has dependencies on both local path crates and registry crates (from crates.io), `cargo metadata` output for the workspace package includes both types in its `dependencies` list. Registry deps only have `source` (e.g., `registry+https://github.com/rust-lang/crates.io-index`) but no `path` key. The current code does:

```python
bazel_target = "//" + paths.join(workspace_package, _normalize_path(dep["path"]).removeprefix(repo_root + "/"))
```

This crashes with `KeyError` on registry deps because `dep["path"]` doesn't exist.

## Fix

Check for the `path` key with `dep.get("path")` before using it. If the dep has no path, skip it with `continue` since registry crates are already handled via the crate hub mechanism.

## Changes

- `rs/extensions.bzl`: Guard against missing `path` key in workspace package dependency iteration