### PR TITLE
perf: pre-filter JSONL lines before json.decode

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -379,7 +379,10 @@ def _generate_hub_and_spokes(
 
                 # TODO(zbarsky): Should we also dedupe this parsing?
                 metadatas = mctx.read(name + ".jsonl").strip().split("\n")
+                version_needle = '"vers":"%s"' % version
                 for metadata in metadatas:
+                    if version_needle not in metadata:
+                        continue
                     metadata = json.decode(metadata)
                     if metadata["vers"] != version:
                         continue


### PR DESCRIPTION
## Summary

Skip `json.decode()` on JSONL lines that don't contain the target version string, avoiding unnecessary JSON parsing for crates with many published versions.

## Problem

When resolving crate metadata from the registry index, every JSONL line (one per published version) is parsed with `json.decode()` even though we only need one specific version. For popular crates like `serde` with 100+ published versions, this means ~99% of JSON parsing is wasted.

While this only affects cold builds (the facts cache makes subsequent builds instant), cold builds are common in CI environments and when onboarding new developers.

## Fix

Add a simple string pre-filter before JSON parsing:

```python
version_needle = '"vers":"%s"' % version
for metadata in metadatas:
    if version_needle not in metadata:
        continue
    metadata = json.decode(metadata)
```

The substring check on the raw JSONL line is safe because:
- The crate index format always encodes the version as `"vers":"X.Y.Z"`
- This format is unambiguous (a version string won't appear as a substring of another field)
- The `json.decode` + version equality check still runs as a final verification

## Changes

- `rs/extensions.bzl`: Add `version_needle` pre-filter in the JSONL scanning loop