### PR TITLE
fix: skip mctx.facts cache for path-dep crates

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -412,36 +412,37 @@ def _generate_hub_and_spokes(
                     # Nest a serialized JSON since max path depth is 5.
                     facts[key] = json.encode(fact)
         elif source.startswith("path+"):
+            # Always re-read path-dep Cargo.toml instead of using cached facts.
+            # Path deps are local (fast to read), and their Cargo.toml can change
+            # features/deps without changing the facts key, causing stale resolution.
+            # Also watch the file so Bazel re-runs the extension when it changes.
             key = source + "_" + name
-            fact = existing_facts.get(key)
-            if fact:
-                facts[key] = fact
-                fact = json.decode(fact)
-            else:
-                annotation = annotation_for(annotations, name, package["version"])
-                cargo_toml_json = run_toml2json(mctx, paths.join(package["local_path"], "Cargo.toml"))
+            cargo_toml_path = paths.join(package["local_path"], "Cargo.toml")
+            mctx.watch(mctx.path(cargo_toml_path))
+            annotation = annotation_for(annotations, name, package["version"])
+            cargo_toml_json = run_toml2json(mctx, cargo_toml_path)
 
-                dependencies = [
-                    _spec_to_dep_dict(dep, spec, annotation, {})
-                    for dep, spec in cargo_toml_json.get("dependencies", {}).items()
-                ] + [
-                    _spec_to_dep_dict(dep, spec, annotation, {}, is_build = True)
-                    for dep, spec in cargo_toml_json.get("build-dependencies", {}).items()
-                ]
+            dependencies = [
+                _spec_to_dep_dict(dep, spec, annotation, {})
+                for dep, spec in cargo_toml_json.get("dependencies", {}).items()
+            ] + [
+                _spec_to_dep_dict(dep, spec, annotation, {}, is_build = True)
+                for dep, spec in cargo_toml_json.get("build-dependencies", {}).items()
+            ]
 
-                for target, value in cargo_toml_json.get("target", {}).items():
-                    for dep, spec in value.get("dependencies", {}).items():
-                        converted = _spec_to_dep_dict(dep, spec, annotation, {})
-                        converted["target"] = target
-                        dependencies.append(converted)
+            for target, value in cargo_toml_json.get("target", {}).items():
+                for dep, spec in value.get("dependencies", {}).items():
+                    converted = _spec_to_dep_dict(dep, spec, annotation, {})
+                    converted["target"] = target
+                    dependencies.append(converted)
 
-                fact = dict(
-                    features = cargo_toml_json.get("features", {}),
-                    dependencies = dependencies,
-                    strip_prefix = "",
-                )
+            fact = dict(
+                features = cargo_toml_json.get("features", {}),
+                dependencies = dependencies,
+                strip_prefix = "",
+            )
 
-                facts[key] = json.encode(fact)
+            facts[key] = json.encode(fact)
             package["strip_prefix"] = fact.get("strip_prefix", "")
         elif source.startswith("git+"):
             key = source + "_" + name


### PR DESCRIPTION
## Summary

Fix stale feature resolution for path-dep crates by bypassing the `mctx.facts` cache and always re-reading their `Cargo.toml`.

## Problem

`mctx.facts` persists across `bazel clean --expunge`. For path-dep crates (source starting with `path+`), the facts key is `source + "_" + name`, which doesn't include any content hash. This means:

1. First build: crate's `Cargo.toml` has no `[features]` section → facts cache stores `features: {}`
2. Developer adds features to the vendored crate's `Cargo.toml`
3. Subsequent builds: stale facts cache returns `features: {}` even after the file changed
4. Feature resolution silently uses wrong features, causing build failures or incorrect behavior

This doesn't affect registry crates (version in key changes) or git crates (commit hash in key changes) — only path deps have this problem because their source path is stable across content changes.

## Fix

- Skip the `existing_facts.get(key)` cache lookup for `path+` sources
- Always call `run_toml2json` to re-read the local `Cargo.toml` (path deps are local files, so this costs ~10ms)
- Add `mctx.watch(mctx.path(cargo_toml_path))` so Bazel re-evaluates the module extension when the file changes

The facts are still written to `mctx.facts` for the current evaluation (needed for downstream resolution), but won't be trusted on the next evaluation.

## Changes

- `rs/extensions.bzl`: Remove facts cache lookup/restore for `path+` sources; add `mctx.watch` on path-dep `Cargo.toml` files