### PR TITLE
fix: add skip_per_crate_rustc_flags to rust_crate.bzl

### DIFF
--- a/rs/rust_crate.bzl
+++ b/rs/rust_crate.bzl
@@ -150,6 +150,7 @@ def rust_crate(
         target_compatible_with = target_compatible_with,
         package_metadata = [name + "_package_metadata"],
         visibility = ["//visibility:public"],
+        skip_per_crate_rustc_flags = True,
     )
 
     if is_proc_macro:


### PR DESCRIPTION
## Summary

Set `skip_per_crate_rustc_flags = True` on generated third-party crate targets in `rust_crate.bzl`, enabling configuration trimming for better cache hit rates.

## Problem

When `experimental_per_crate_rustc_flag` is set in rules_rust (e.g., to pass extra flags to first-party crates matching a `//` prefix), all third-party crates are placed into a different Bazel configuration even though the per-crate flags never match them. This causes unnecessary rebuilds of every third-party crate whenever the flag value changes.

## Fix

Pass `skip_per_crate_rustc_flags = True` to the `rust_library` / `rust_proc_macro` call in `rust_crate()`. This leverages the corresponding rules_rust attribute (added in [bazelbuild/rules_rust#XXXX]) to trim the `experimental_per_crate_rustc_flag` setting from the configuration of third-party crates, returning them to a canonical configuration.

## Dependency

This change requires rules_rust to have the `skip_per_crate_rustc_flags` attribute defined. Without it, Bazel will error on the unknown attribute. The rules_rust PR adding this attribute is being submitted in parallel.

## Changes

- `rs/rust_crate.bzl`: Add `skip_per_crate_rustc_flags = True` to the kwargs dict passed to `rust_library`/`rust_proc_macro`