### PR TITLE
fix: cross-output-base symlink breakage in crate_git_repository

### DIFF
--- a/rs/private/crate_git_repository.bzl
+++ b/rs/private/crate_git_repository.bzl
@@ -1,3 +1,5 @@
+"""Repository rule for git-sourced crates with strip_prefix support."""
+
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load(":repository_utils.bzl", "common_attrs", "generate_build_file")
 load(":toml2json.bzl", "run_toml2json")
@@ -32,7 +34,7 @@ def _crate_git_repository_implementation(rctx):
         "--force",
         "--force",
         "--detach",
-        "HEAD"
+        "HEAD",
     ])
     if result.return_code != 0:
         fail(result.stderr)
@@ -42,7 +44,18 @@ def _crate_git_repository_implementation(rctx):
         if not dest_link.exists:
             fail("strip_prefix at {} does not exist in repo".format(strip_prefix))
         for item in dest_link.readdir():
-            rctx.symlink(item, root.get_child(item.basename))
+            # Use relative symlinks so the repo remains valid when served from
+            # Bazel's repository_cache to a different output base.  Absolute
+            # symlinks (what rctx.symlink produces) embed the original output
+            # base path and break on reuse.
+            ln_result = rctx.execute([
+                "ln",
+                "-sf",
+                ".tmp_git_root/" + strip_prefix + "/" + item.basename,
+                str(root.get_child(item.basename)),
+            ])
+            if ln_result.return_code != 0:
+                fail("symlink failed for {}: {}".format(item.basename, ln_result.stderr))
 
     patch(rctx)
 


### PR DESCRIPTION
## Summary

Replace absolute symlinks with relative ones in `crate_git_repository` to fix breakage when Bazel's `--repository_cache` serves a cached repo to a different output base.

## Problem

`crate_git_repository` uses `rctx.symlink()` to link files from a `strip_prefix` subdirectory to the repo root. `rctx.symlink()` creates **absolute** symlinks that embed the full output base path, e.g.:

```
src/lib.rs -> /home/alice/.cache/bazel/_bazel_alice/abc123/external/.tmp_git_root/crate-x/src/lib.rs
```

When `--repository_cache` is enabled (which it typically is), Bazel caches the entire repository directory. If a different invocation with a different output base (e.g., a CI job running as a different user, or a different Bazel workspace) reuses this cached repo, the absolute symlinks point to non-existent paths:

```
src/lib.rs -> /home/alice/.cache/bazel/_bazel_alice/abc123/...  # but we're in bob's output base
```

This causes "No such file or directory" errors for any crate using `strip_prefix`.

## Fix

Replace `rctx.symlink(item, root.get_child(item.basename))` with `ln -sf` using relative paths:

```python
rctx.execute([
    "ln", "-sf",
    ".tmp_git_root/" + strip_prefix + "/" + item.basename,
    str(root.get_child(item.basename)),
])
```

Relative symlinks are output-base-independent, so they remain valid regardless of which output base the cached repo is served to.

## Additional changes

- Added module docstring to `crate_git_repository.bzl`
- Fixed trailing comma in `git worktree add` argument list

## Changes

- `rs/private/crate_git_repository.bzl`: Replace `rctx.symlink` with relative `ln -sf` for strip_prefix files