### PR TITLE
fix: syntax in extra_rustc_flags selection

### DIFF
--- a/rs/experimental/toolchains/declare_rustc_toolchains.bzl
+++ b/rs/experimental/toolchains/declare_rustc_toolchains.bzl
@@ -101,7 +101,7 @@ def declare_rustc_toolchains(
             default_edition = edition,
             extra_exec_rustc_flags = extra_exec_rustc_flags.get(triple),
             extra_rustc_flags = select(
-                {"@rules_rs//rs/experimental/platforms/config:" + triple: flags for triple, flags in extra_rustc_flags.items} |
+                {"@rules_rs//rs/experimental/platforms/config:" + triple: flags for triple, flags in extra_rustc_flags.items()} |
                 {"//conditions:default": []},
             ),
             exec_triple = triple,


### PR DESCRIPTION
Error: type 'builtin_function_or_method' is not iterable