### PR TITLE
fix: don't include .git in crates

### DIFF
--- a/rs/private/crate_git_repository.bzl
+++ b/rs/private/crate_git_repository.bzl
@@ -109,6 +109,9 @@ def _crate_git_repository_implementation(rctx):
 
     rctx.file("BUILD.bazel", generate_build_file(rctx, cargo_toml, purl_qualifiers = {"vcs_url": vcs_url}))
 
+    # Since we're using `git` to download the repo, remove
+    # the `.git` to make sure it's reproducible.
+    rctx.delete(root.get_child(".git"))
     return rctx.repo_metadata(reproducible = True)
 
 crate_git_repository = repository_rule(

--- a/rs/rust_crate.bzl
+++ b/rs/rust_crate.bzl
@@ -46,6 +46,7 @@ def rust_crate(
         include = ["**"],
         exclude = [
             "**/* *",
+            ".git",
             ".tmp_git_root/**/*",
             "BUILD",
             "BUILD.bazel",


### PR DESCRIPTION
See https://github.com/openai/codex/pull/16590

We don't want to include the `.git` in the glob for the crate since this causes the compile action to be non-deterministic if the user is using a crate_git_repository

Repro with:
```
  bazel aquery --output=text 'mnemonic("Rustc", @@rules_rs++crate+crates__nucleo-0.5.0//:nucleo)' \
    | tr ',' '\n' \
    | sed 's/^ *//; s/ *$//' \
    | grep '^external/rules_rs++crate+crates__nucleo-0.5.0/.git$'
```