### PR TITLE
Avoid marking reproducible on external repos that create non-local symlinks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,8 +20,8 @@ license(
 
 platform(
     name = "local_gnu_platform",
-    parents = ["@platforms//host"],
     constraint_values = [
         "@llvm//constraints/libc:gnu.2.28",
     ],
+    parents = ["@platforms//host"],
 )

--- a/rs/BUILD.bazel
+++ b/rs/BUILD.bazel
@@ -5,7 +5,6 @@ bzl_library(
     srcs = ["extensions.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "//rs/private:repository_utils",
         "//rs/private:annotations",
         "//rs/private:cargo_credentials",
         "//rs/private:cfg_parser",
@@ -14,6 +13,7 @@ bzl_library(
         "//rs/private:downloader",
         "//rs/private:git_repository",
         "//rs/private:lint_flags",
+        "//rs/private:repository_utils",
         "//rs/private:resolver",
         "//rs/private:select_utils",
         "//rs/private:semver",

--- a/rs/experimental/toolchains/BUILD.bazel
+++ b/rs/experimental/toolchains/BUILD.bazel
@@ -52,6 +52,7 @@ bzl_library(
         "//rs/private:rustfmt_repository",
         "//rs/private:stdlib_repository",
         "//rs/private:toolchains_repository",
+        "@bazel_features//:features",
         "@rules_rust//rust/platform:bzl_lib",
         "@rules_rust//rust/private:bzl_lib",
     ],

--- a/rs/private/clippy_repository.bzl
+++ b/rs/private/clippy_repository.bzl
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_rust//rust/platform:triple.bzl", "triple")
 load("@rules_rust//rust/private:repository_utils.bzl", "BUILD_for_clippy")
 load(":rust_repository_utils.bzl", "download_and_extract", "RUST_REPOSITORY_COMMON_ATTR")
@@ -10,7 +11,9 @@ def _clippy_repository_impl(rctx):
     rustc_repo_root = rctx.path(rctx.attr.rustc_repo_build_file).dirname
     rctx.symlink(rustc_repo_root.get_child("lib"), "lib")
 
-    return rctx.repo_metadata(reproducible = True)
+    return rctx.repo_metadata(
+        reproducible = bazel_features.external_deps.repo_rules_relativize_symlinks,
+    )
 
 clippy_repository = repository_rule(
     implementation = _clippy_repository_impl,

--- a/rs/private/crate_repository.bzl
+++ b/rs/private/crate_repository.bzl
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load(":cargo_credentials.bzl", "load_cargo_credentials", "registry_auth_headers")
@@ -60,7 +61,9 @@ def _local_crate_repository_impl(rctx):
 
     rctx.file("BUILD.bazel", generate_build_file(rctx, cargo_toml))
 
-    return rctx.repo_metadata(reproducible = True)
+    return rctx.repo_metadata(
+        reproducible = bazel_features.external_deps.repo_rules_relativize_symlinks,
+    )
 
 local_crate_repository = repository_rule(
     implementation = _local_crate_repository_impl,

--- a/rs/private/rustfmt_repository.bzl
+++ b/rs/private/rustfmt_repository.bzl
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_rust//rust/platform:triple.bzl", "triple")
 load("@rules_rust//rust/private:repository_utils.bzl", "BUILD_for_rustfmt")
 load(":rust_repository_utils.bzl", "download_and_extract", "RUST_REPOSITORY_COMMON_ATTR")
@@ -24,7 +25,9 @@ def _rustfmt_repository_impl(rctx):
     rustc_repo_root = rctx.path(rctx.attr.rustc_repo_build_file).dirname
     rctx.symlink(rustc_repo_root.get_child("lib"), "lib")
 
-    return rctx.repo_metadata(reproducible = True)
+    return rctx.repo_metadata(
+        reproducible = bazel_features.external_deps.repo_rules_relativize_symlinks,
+    )
 
 rustfmt_repository = repository_rule(
     implementation = _rustfmt_repository_impl,

--- a/tools/rust_analyzer/BUILD.bazel
+++ b/tools/rust_analyzer/BUILD.bazel
@@ -52,10 +52,10 @@ rust_binary(
     },
     toolchains = ["@rules_rust//rust/toolchain:current_rust_analyzer_toolchain"],
     deps = [
-        "@rules_rust//rust/runfiles",
         "@rrra//:clap",
         "@rrra//:env_logger",
         "@rrra//:log",
+        "@rules_rust//rust/runfiles",
     ],
 )
 
@@ -71,13 +71,13 @@ rust_library(
     ],
     edition = "2018",
     deps = [
-        "@rules_rust//rust/runfiles",
         "@rrra//:anyhow",
         "@rrra//:camino",
         "@rrra//:clap",
         "@rrra//:log",
         "@rrra//:serde",
         "@rrra//:serde_json",
+        "@rules_rust//rust/runfiles",
     ],
 )
 
@@ -99,7 +99,6 @@ rust_clippy(
 
 bzl_library(
     name = "bzl_lib",
-    srcs = ["defs.bzl"],
     deps = [
         "@bazel_features//:features",
         "@rules_rust//rust:bzl_lib",


### PR DESCRIPTION
Such symlinks cannot work with local repository cache, and Bazel versions prior to this one would cache them there, breaking builds across output bases. With this bazel_feature gate passing, these repos will be eligible for the remote repo contents cache, but not the local one.