### PR TITLE
chore: open BCR prs in draft mode

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,12 +21,12 @@ on:
         type: string
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
     with:
       tag_name: ${{ inputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: hermeticbuild/bazel-central-registry
-      draft: false
+      draft: true
       attest: true
     permissions:
       attestations: write


### PR DESCRIPTION
The BCR has a mechanism where a module maintainer can mark the PR as "ready for review" as a way to auto-approve and merge it. This is the recommended approach when the PRs are opened as an individual rather than a machine account as in https://github.com/bazelbuild/bazel-central-registry/pull/8569.

See https://github.com/bazel-contrib/publish-to-bcr#4-consider-whether-to-open-the-pr-as-a-draft.