### PR TITLE
Add Nativelink

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ See https://registry.bazel.build/docs/rules_rs
 - [JetBrains](https://github.com/JetBrains/intellij-community), used in closed sources of [JetBrains Air](https://air.dev/)
 - [Perplexity](https://perplexity.ai)
 - [formatjs](https://github.com/formatjs/formatjs)
+- [Trace Machina Nativelink](https://github.com/TraceMachina/nativelink)
 
 ## Telemetry And Privacy Policy
 


### PR DESCRIPTION
[Nativelink](https://github.com/TraceMachina/nativelink) had been heavily dependent upon Nix for managing Rust toolchains until `rules_rs` offered a more streamlined and ergonomic alternative. We will look to support with any contributions we need to make upstream as well.