### PR TITLE
local_crate_repository: mark non-reproducible

### DIFF
--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -47,7 +47,6 @@ bzl_library(
         ":registry_utils",
         ":repository_utils",
         ":toml2json",
-        "@bazel_features//:features",
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],

--- a/rs/private/crate_repository.bzl
+++ b/rs/private/crate_repository.bzl
@@ -1,4 +1,3 @@
-load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load(":cargo_credentials.bzl", "load_cargo_credentials", "registry_auth_headers")
@@ -98,9 +97,14 @@ def _local_crate_repository_impl(rctx):
 
     rctx.file("BUILD.bazel", _generate_build_file(rctx, cargo_toml))
 
-    return rctx.repo_metadata(
-        reproducible = bazel_features.external_deps.repo_rules_relativize_symlinks,
-    )
+    # Symlinks into the main workspace get replanted by Bazel >= 9.0.1 as
+    # relative `..\_main\...` paths before reproducible repos enter the
+    # contents cache. On Windows those paths dangle from the action
+    # execroot (no `execroot/_main/external/_main`), so actions fail to
+    # read the crate sources. Marking non-reproducible skips replanting
+    # and keeps the original absolute symlinks, which resolve from both
+    # views. See https://github.com/bazelbuild/bazel/issues/29515.
+    return rctx.repo_metadata(reproducible = False)
 
 local_crate_repository = repository_rule(
     implementation = _local_crate_repository_impl,


### PR DESCRIPTION
`local_crate_repository` symlinks files from the main workspace into its external repo. Bazel >= 9.0.1 replants those symlinks as relative `..\_main\...` paths when placing reproducible repos in the contents cache. On Windows the replanted paths dangle from the action execroot (no `execroot/_main/external/_main`), so actions fail to read the crate sources.

Mark these repos non-reproducible unconditionally so the original absolute symlinks survive on every platform. The tradeoff is loss of remote-repo-contents-cache eligibility; the only per-invocation work that re-runs on a cold output_base is the toml2json parse and BUILD.bazel generation, which is negligible.

See https://github.com/bazelbuild/bazel/issues/29515.