### PR TITLE
Sanitize macOS rust-lld RPATH in generated toolchain

### DIFF
--- a/rs/private/rustc_repository.bzl
+++ b/rs/private/rustc_repository.bzl
@@ -54,17 +54,62 @@ def _symlink_rust_objcopy_shared_libraries(rctx, exec_triple):
         if entry.basename.startswith("libLLVM"):
             rctx.symlink(entry, "{}/{}".format(rustlib_lib, entry.basename))
 
+_MACOS_RUST_LLD_BUILD = """\
+genrule(
+    name = "sanitize-rust-lld",
+    srcs = ["lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}"],
+    outs = ["sanitized/rust-lld{binary_ext}"],
+    tools = [
+        "@llvm//tools:llvm-install-name-tool",
+        "@llvm//tools:llvm-otool",
+    ],
+    cmd = '''
+set -euo pipefail
+cp -p "$<" "$@"
+chmod u+w "$@"
+leaked_rpath="/Users/runner/work/rust/rust/build/{target_triple}/llvm/lib"
+if "$(location @llvm//tools:llvm-otool)" -l "$@" | grep -Fq "path $${{leaked_rpath}} "; then
+    "$(location @llvm//tools:llvm-install-name-tool)" -delete_rpath "$${{leaked_rpath}}" "$@"
+fi
+chmod +x "$@"
+''',
+    executable = True,
+)
+
+filegroup(
+    name = "rust-lld",
+    srcs = [":sanitize-rust-lld"],
+    data = glob(
+        include = [
+            "lib/rustlib/{target_triple}/bin/*-ld{binary_ext}",
+            "lib/rustlib/{target_triple}/bin/gcc-ld/*",
+        ],
+        exclude = [
+            "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+"""
+
 def _rustc_repository_impl(rctx):
     exec_triple = triple(rctx.attr.triple)
     download_and_extract(rctx, "rustc", "rustc", exec_triple)
+
     # Upstream Linux rustc bundles libLLVM, which dynamically links against libz.so.1.
     _add_linux_zlib(rctx, exec_triple)
     _symlink_rust_objcopy_shared_libraries(rctx, exec_triple)
     build_content = [BUILD_for_compiler(
         exec_triple,
-        include_linker = True,
+        include_linker = exec_triple.system != "macos",
         include_objcopy = True,
     )]
+    if exec_triple.system == "macos":
+        build_content.append(_MACOS_RUST_LLD_BUILD.format(
+            binary_ext = "",
+            target_triple = exec_triple.str,
+        ))
     if includes_rust_analyzer_proc_macro_srv(rctx.attr.version, rctx.attr.iso_date):
         build_content.append(BUILD_for_rust_analyzer_proc_macro_srv(exec_triple))
     rctx.file("BUILD.bazel", "\n".join(build_content))


### PR DESCRIPTION
### Motivation
- Upstream macOS `rust-lld` binaries include an absolute `LC_RPATH` pointing at the Rust CI builder (`/Users/runner/work/rust/rust/build/<triple>/llvm/lib`), which leaks build provenance and creates a latent dylib-search risk. 

### Description
- Add a macOS-specific BUILD fragment (`_MACOS_RUST_LLD_BUILD`) that provides a `genrule(name = "sanitize-rust-lld")` which copies the upstream `rust-lld` and removes the leaked RPATH when present using `@llvm//tools:llvm-otool` and `@llvm//tools:llvm-install-name-tool`.
- Make `include_linker` conditional so non-macOS toolchains continue to use the upstream `BUILD_for_compiler` linker target while macOS toolchains append the sanitized `rust-lld` filegroup.
- Preserve the public `rust-lld` filegroup interface and its auxiliary linker data so consumers see the same targets while macOS gets the sanitized binary.

### Testing
- Ran `bazel query //rs/private:rustc_repository` to validate repository rule visibility and this succeeded.
- Built a temporary package with the sanitized target via `bazel build //.tmp_rust_lld_build_check:rust-lld` and the build completed successfully.
- Formatted/checked the edited file with the repository `buildifier` invocation `bazel run @buildifier_prebuilt//:buildifier -- /workspace/rules_rs/rs/private/rustc_repository.bzl` and it ran successfully.
- Ran `git diff --check` to ensure there are no whitespace/errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25fb1bf13083339a7f639be9fedc69)