### PR TITLE
Sanitize MacOS LLD rpath

### DIFF
--- a/rs/private/rustc_repository.bzl
+++ b/rs/private/rustc_repository.bzl
@@ -54,17 +54,65 @@ def _symlink_rust_objcopy_shared_libraries(rctx, exec_triple):
         if entry.basename.startswith("libLLVM"):
             rctx.symlink(entry, "{}/{}".format(rustlib_lib, entry.basename))
 
+# Routes the macOS rust-lld through the sanitize_rust_lld rule (see that file for
+# why this is a build action and not repository-rule work). The public rust-lld
+# filegroup interface is preserved: srcs is the sanitized binary, data carries
+# the auxiliary linker tools unchanged. exec_compatible_with pins the action to a
+# macOS execution platform so it lands on the laptop or macOS RBE worker that
+# actually uses rust-lld.
+_MACOS_RUST_LLD_LOAD = 'load("@rules_rs//rs/private:sanitize_rust_lld.bzl", "sanitize_rust_lld")'
+
+_MACOS_RUST_LLD_BUILD = """\
+sanitize_rust_lld(
+    name = "sanitized-rust-lld",
+    src = "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
+    target_triple = "{target_triple}",
+    exec_compatible_with = ["@platforms//os:macos"],
+)
+
+filegroup(
+    name = "rust-lld",
+    srcs = [":sanitized-rust-lld"],
+    data = glob(
+        include = [
+            "lib/rustlib/{target_triple}/bin/*-ld{binary_ext}",
+            "lib/rustlib/{target_triple}/bin/gcc-ld/*",
+        ],
+        exclude = [
+            "lib/rustlib/{target_triple}/bin/rust-lld{binary_ext}",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+"""
+
 def _rustc_repository_impl(rctx):
     exec_triple = triple(rctx.attr.triple)
     download_and_extract(rctx, "rustc", "rustc", exec_triple)
+
     # Upstream Linux rustc bundles libLLVM, which dynamically links against libz.so.1.
     _add_linux_zlib(rctx, exec_triple)
     _symlink_rust_objcopy_shared_libraries(rctx, exec_triple)
-    build_content = [BUILD_for_compiler(
+
+    is_macos = exec_triple.system == "macos"
+
+    # On macOS the linker filegroup is emitted by _MACOS_RUST_LLD_BUILD below so
+    # that rust-lld is routed through the rpath-sanitizing rule; everywhere else
+    # the upstream linker filegroup is used unchanged.
+    build_content = []
+    if is_macos:
+        build_content.append(_MACOS_RUST_LLD_LOAD)
+    build_content.append(BUILD_for_compiler(
         exec_triple,
-        include_linker = True,
+        include_linker = not is_macos,
         include_objcopy = True,
-    )]
+    ))
+    if is_macos:
+        build_content.append(_MACOS_RUST_LLD_BUILD.format(
+            binary_ext = "",
+            target_triple = exec_triple.str,
+        ))
     if includes_rust_analyzer_proc_macro_srv(rctx.attr.version, rctx.attr.iso_date):
         build_content.append(BUILD_for_rust_analyzer_proc_macro_srv(exec_triple))
     rctx.file("BUILD.bazel", "\n".join(build_content))

--- a/rs/private/sanitize_rust_lld.bzl
+++ b/rs/private/sanitize_rust_lld.bzl
@@ -1,0 +1,61 @@
+"""Strips the leaked upstream CI LC_RPATH from the macOS rust-lld binary.
+
+Upstream macOS rust-lld ships an absolute LC_RPATH pointing at the Rust
+project's CI builder (/Users/runner/work/rust/rust/build/<triple>/llvm/lib).
+It is inert today (rust-lld has no @rpath dependencies) but leaks the upstream
+build layout and is flagged by relocatability/provenance scanners.
+
+This is a build action rather than repository-rule work: a repository rule runs
+on the machine driving Bazel -- often a non-macOS scheduler under remote
+execution -- and cannot re-sign a Mach-O binary. The action runs wherever
+rust-lld is consumed (a dev laptop or a macOS remote-execution worker), keyed to
+the macOS execution platform by the caller. It uses Apple's install_name_tool,
+which re-signs the ad-hoc signature that Apple Silicon requires after a load
+command is removed; using it instead of @llvm//tools avoids forcing an LLVM
+download onto every downstream consumer. All tools are referenced by absolute
+path so the action does not depend on the worker's PATH.
+"""
+
+# Positional args ($1 src, $2 out, $3 leaked rpath) keep all quoting in Starlark
+# rather than in a BUILD-embedded command string.
+_SANITIZE_CMD = """\
+set -euo pipefail
+src="$1"
+out="$2"
+leaked_rpath="$3"
+/bin/cp -p "$src" "$out"
+/bin/chmod u+w "$out"
+if /usr/bin/otool -l "$out" | /usr/bin/grep -Fq "path $leaked_rpath "; then
+    /usr/bin/install_name_tool -delete_rpath "$leaked_rpath" "$out"
+fi
+/bin/chmod +x "$out"
+"""
+
+def _sanitize_rust_lld_impl(ctx):
+    out = ctx.actions.declare_file("{}/rust-lld".format(ctx.label.name))
+    leaked_rpath = "/Users/runner/work/rust/rust/build/{}/llvm/lib".format(ctx.attr.target_triple)
+    ctx.actions.run_shell(
+        inputs = [ctx.file.src],
+        outputs = [out],
+        command = _SANITIZE_CMD,
+        arguments = [ctx.file.src.path, out.path, leaked_rpath],
+        mnemonic = "SanitizeRustLld",
+        progress_message = "Stripping leaked rpath from %{input}",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+sanitize_rust_lld = rule(
+    implementation = _sanitize_rust_lld_impl,
+    doc = "Emits rust-lld with the leaked upstream CI LC_RPATH removed (macOS only).",
+    attrs = {
+        "src": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "The upstream rust-lld binary to sanitize.",
+        ),
+        "target_triple": attr.string(
+            mandatory = True,
+            doc = "Exec triple whose leaked CI build path should be stripped.",
+        ),
+    },
+)


### PR DESCRIPTION
## Sanitize leaked CI `LC_RPATH` from macOS `rust-lld` (fixes #141)

### Problem

Upstream macOS `rust-lld` ships an absolute `LC_RPATH` pointing at the Rust project's CI builder: `/Users/runner/work/rust/rust/build/<triple>/llvm/lib`. It's inert today (`rust-lld` has no `@rpath/...` deps) but leaks the upstream build layout and trips relocatability / SBOM / SLSA provenance scanners.

### Fix

Strip the rpath with a build action keyed to the macOS execution platform, not in the repository rule. A repository rule runs on the machine driving Bazel, which is often a non-macOS scheduler under remote execution, and it cannot re-sign a Mach-O binary. The action runs wherever rust-lld is actually consumed (a dev laptop or a macOS remote-execution worker).

Implemented as a custom rule, consistent with the rest of the ruleset (the codebase uses `ctx.actions` rules and no genrules). Two files:

- `rs/private/sanitize_rust_lld.bzl` (new): a `sanitize_rust_lld` rule. It copies rust-lld and runs `otool` plus `install_name_tool -delete_rpath`. Tools are referenced by absolute path so the action does not depend on the worker's PATH, and arguments are positional so no shell quoting lives in a BUILD file.
- `rs/private/rustc_repository.bzl`: on macOS triples the generated BUILD loads the rule, instantiates it with `exec_compatible_with = ["@platforms//os:macos"]`, and keeps the public rust-lld filegroup interface unchanged (srcs is the sanitized binary, data is the upstream auxiliary linker glob). `include_linker` is suppressed only on macOS.

### Why install_name_tool
Apple Silicon requires every executable to carry a valid code signature, so removing a load command invalidates the binary unless it is re-signed. Apple's `install_name_tool` re-signs the ad-hoc signature automatically, which is why it is used here rather than `@llvm//tools` (which would also force an LLVM download onto every downstream consumer). References:

- install_name_tool man page: https://keith.github.io/xcode-man-pages/install_name_tool.1.html
- Apple Silicon code-signing requirement: https://developer.apple.com/documentation/apple-silicon/porting-your-macos-apps-to-apple-silicon