### PR TITLE
Add opt_level to toolchain

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -398,6 +398,69 @@
         }
       }
     },
+    "@@llvm+//3rd_party/gcc/extension:gcc.bzl%gcc": {
+      "general": {
+        "bzlTransitiveDigest": "XUWTels9SzO7xhmQBqYtaFYFMTjrFMSDFi/Q7hv4f34=",
+        "usagesDigest": "9IP/e++b81Ga1zICxzXu+yqfe5i4DX5F/SsrgV5a568=",
+        "recordedInputs": [
+          "REPO_MAPPING:llvm+,bazel_lib bazel_lib+",
+          "REPO_MAPPING:llvm+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "gcc": {
+            "repoRuleId": "@@llvm+//:http_bsdtar_archive.bzl%http_bsdtar_archive",
+            "attributes": {
+              "build_file": "@@llvm+//3rd_party/gcc:gcc.BUILD.bazel",
+              "includes": [
+                "gcc/BASE-VER",
+                "gcc/DATESTAMP",
+                "gcc/ginclude/unwind-arm-common.h",
+                "config/acx.m4",
+                "config/cet.m4",
+                "config/futex.m4",
+                "config/gc++filt.m4",
+                "config/gthr.m4",
+                "config/hwcaps.m4",
+                "config/iconv.m4",
+                "config/lthostflags.m4",
+                "config/multi.m4",
+                "config/no-executables.m4",
+                "config/tls.m4",
+                "config/toolexeclibdir.m4",
+                "config/unwind_ipinfo.m4",
+                "include/ansidecl.h",
+                "include/demangle.h",
+                "include/dyn-string.h",
+                "include/getopt.h",
+                "include/libiberty.h",
+                "libgcc/gthr-posix.h",
+                "libgcc/gthr-single.h",
+                "libgcc/gthr.h",
+                "libgcc/config/arm/unwind-arm.h",
+                "libgcc/unwind-generic.h",
+                "libgcc/unwind-pe.h",
+                "libiberty/cp-demangle.c",
+                "libiberty/cp-demangle.h",
+                "libstdc++-v3/acinclude.m4",
+                "libstdc++-v3/config/**",
+                "libstdc++-v3/configure.ac",
+                "libstdc++-v3/configure.host",
+                "libstdc++-v3/crossconfig.m4",
+                "libstdc++-v3/linkage.m4",
+                "libstdc++-v3/include/**",
+                "libstdc++-v3/libsupc++/**",
+                "libstdc++-v3/src/**"
+              ],
+              "sha256": "dc033fdfd79caf199113446af6d082004534437b6ebd276f9732815d86cbe723",
+              "strip_prefix": "gcc-2bfd402f8569511901ec8fe7628f57471e6d240a",
+              "urls": [
+                "https://github.com/gcc-mirror/gcc/archive/2bfd402f8569511901ec8fe7628f57471e6d240a.tar.gz"
+              ]
+            }
+          }
+        }
+      }
+    },
     "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
       "general": {
         "bzlTransitiveDigest": "pmsA+awieucfllLc2n7k8xEoPp0i5LF9Hw6mGX0cqSQ=",

--- a/rs/private/toolchains_repository.bzl
+++ b/rs/private/toolchains_repository.bzl
@@ -1,3 +1,5 @@
+"""Toolchain repository"""
+
 def _toolchains_repository_impl(rctx):
     rctx.file(
         "BUILD.bazel",
@@ -11,6 +13,7 @@ declare_rustc_toolchains(
     edition = {edition},
     extra_rustc_flags = {extra_rustc_flags},
     extra_exec_rustc_flags = {extra_exec_rustc_flags},
+    opt_level = {opt_level},
 )
 
 declare_rustfmt_toolchains(
@@ -30,6 +33,7 @@ declare_rust_analyzer_toolchains(
             edition = repr(rctx.attr.edition),
             extra_rustc_flags = repr(rctx.attr.extra_rustc_flags),
             extra_exec_rustc_flags = repr(rctx.attr.extra_exec_rustc_flags),
+            opt_level = repr(rctx.attr.opt_level),
         ),
     )
 
@@ -44,5 +48,6 @@ toolchains_repository = repository_rule(
         "edition": attr.string(mandatory = True),
         "extra_rustc_flags": attr.string_list_dict(),
         "extra_exec_rustc_flags": attr.string_list_dict(),
+        "opt_level": attr.string_dict(),
     },
 )

--- a/rs/toolchains/declare_rustc_toolchains.bzl
+++ b/rs/toolchains/declare_rustc_toolchains.bzl
@@ -1,3 +1,5 @@
+"""Toolchain declaration"""
+
 load("@rules_rust//rust:toolchain.bzl", "rust_toolchain")
 load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load("//rs/platforms:triples.bzl", "ALL_TARGET_TRIPLES", "SUPPORTED_EXEC_TRIPLES", "SUPPORTED_TIER_3_TRIPLES", "triple_to_rust_constraint_set")
@@ -23,14 +25,27 @@ def _rustc_flags_to_select(rustc_flags_by_triple):
     )
 
 def declare_rustc_toolchains(
+        name = None,
         *,
         version,
         edition,
         extra_rustc_flags = {},
         extra_exec_rustc_flags = {},
+        opt_level = {},
         execs = SUPPORTED_EXEC_TRIPLES,
         targets = ALL_TARGET_TRIPLES):
-    """Declare toolchains for all supported target platforms."""
+    """Declare toolchains for all supported target platforms.
+
+    Args:
+        name: Unused; required by Bazel macro naming convention.
+        version: Rust version string (e.g. "1.86.0" or "nightly/2025-04-03").
+        edition: Default Rust edition to apply to toolchains (e.g. "2021").
+        extra_rustc_flags: Additional rustc flags keyed by target triple.
+        extra_exec_rustc_flags: Additional rustc flags keyed by exec triple.
+        opt_level: Rustc optimization levels per Bazel compilation mode.
+        execs: Exec triples to declare toolchains for.
+        targets: Target triples to declare toolchains for.
+    """
 
     version_key = sanitize_version(version)
     channel = _channel(version)
@@ -155,6 +170,7 @@ def declare_rustc_toolchains(
             default_edition = edition,
             extra_exec_rustc_flags = _rustc_flags_to_select(extra_exec_rustc_flags),
             extra_rustc_flags = _rustc_flags_to_select(extra_rustc_flags),
+            opt_level = opt_level if opt_level else None,
             exec_triple = triple,
             target_triple = select(target_triple_select),
             visibility = ["//visibility:public"],

--- a/rs/toolchains/module_extension.bzl
+++ b/rs/toolchains/module_extension.bzl
@@ -2,12 +2,12 @@
 
 load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load(
-    "@rules_rust//rust/private:repository_utils.bzl",
+    "@rules_rust//rust/private:repository_utils.bzl",  # buildifier: disable=bzl-visibility
     "DEFAULT_STATIC_RUST_URL_TEMPLATES",
     "check_version_valid",
     "produce_tool_suburl",
 )
-load("//rs/experimental/miri/private:miri_repository.bzl", "miri_repository")
+load("//rs/experimental/miri/private:miri_repository.bzl", "miri_repository")  # buildifier: disable=bzl-visibility
 load("//rs/platforms:triples.bzl", "SUPPORTED_EXEC_TRIPLES", "SUPPORTED_TIER_1_AND_2_TRIPLES")
 load("//rs/private:bpf_linker_repository.bzl", "BPF_LINKER_SUPPORTED_EXEC_TRIPLES", "declare_bpf_linker_repository")
 load("//rs/private:cargo_repository.bzl", "cargo_repository")
@@ -91,6 +91,14 @@ _TOOLCHAIN_TAG = tag_class(
         "extra_exec_rustc_flags": attr.string_list_dict(
             doc = "Additional rustc flags by exec triple.",
         ),
+        "opt_level": attr.string_dict(
+            doc = "Rustc optimization levels per Bazel compilation mode. " +
+                  "Keys are 'dbg', 'fastbuild', 'opt'. " +
+                  "Values are rustc opt-level strings: '0', '1', '2', '3', 's', 'z'. " +
+                  "Defaults to the rules_rust toolchain default: " +
+                  "{\"dbg\": \"0\", \"fastbuild\": \"0\", \"opt\": \"3\"}.",
+            default = {},
+        ),
     },
 )
 
@@ -169,6 +177,7 @@ def _toolchains_impl(mctx):
             edition = _DEFAULT_EDITION,
             extra_rustc_flags = {},
             extra_exec_rustc_flags = {},
+            opt_level = {},
         ))
 
     versions = set([])
@@ -438,7 +447,8 @@ def _toolchains_impl(mctx):
             (existing.rust_analyzer_version or existing.version) != rust_analyzer_version or
             existing.edition != tag.edition or
             existing.extra_rustc_flags != tag.extra_rustc_flags or
-            existing.extra_exec_rustc_flags != tag.extra_exec_rustc_flags
+            existing.extra_exec_rustc_flags != tag.extra_exec_rustc_flags or
+            existing.opt_level != tag.opt_level
         ):
             fail("Toolchain repo {} has conflicting tag configurations".format(repo_name))
 
@@ -452,6 +462,7 @@ def _toolchains_impl(mctx):
                 edition = tag.edition,
                 extra_rustc_flags = tag.extra_rustc_flags,
                 extra_exec_rustc_flags = tag.extra_exec_rustc_flags,
+                opt_level = tag.opt_level,
             )
         is_dev_dependency = had_tags and mctx.is_dev_dependency(tag)
         if is_dev_dependency:

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -52,6 +52,7 @@ DISABLED = [
     "3rd_party",
     "pyo3",
     "prost",
+    "toolchain_opt_level",
     "wasm_bindgen",
     #"binaries",
     #"build_script_aliases",
@@ -83,8 +84,8 @@ rust_binary(
     srcs = ["main.rs"],
     deps = [
         "@many_workspace_deps//:actix-web",
-        "@many_workspace_deps//:apriltag",
         "@many_workspace_deps//:apple-codesign",
+        "@many_workspace_deps//:apriltag",
         "@many_workspace_deps//:axum",
         "@many_workspace_deps//:ballista",
         "@many_workspace_deps//:cssparser",
@@ -344,6 +345,7 @@ filegroup(
             ":verify_rust_analyzer_toolchain",
             ":verify_vendored_workspace_dep",
             ":verify_workspace_member_annotation_features",
+            "//toolchain_opt_level:verify_toolchain_opt_level",
         ],
     }),
 )
@@ -366,7 +368,10 @@ LINUX_GNU_PLATFORMS = {
     platform_transition_filegroup(
         name = "all_builds_" + platform,
         srcs = ["all_builds"],
-        target_platform = LINUX_GNU_PLATFORMS.get(platform, "@rules_rs//rs/platforms:" + platform),
+        target_platform = LINUX_GNU_PLATFORMS.get(
+            platform,
+            "@rules_rs//rs/platforms:" + platform,
+        ),
     )
     for platform in ALL_PLATFORMS
 ]

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -127,6 +127,11 @@ crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")
 toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")
 toolchains.toolchain(
     edition = "2024",
+    opt_level = {
+        "dbg": "0",
+        "fastbuild": "0",
+        "opt": "2",
+    },
     version = "1.92.0",
 )
 toolchains.experimental_miri(version = "nightly/2026-04-20")
@@ -218,7 +223,6 @@ crate.from_cargo(
     ],
 )
 use_repo(crate, "root_package")
-
 crate.annotation(
     crate = "rustls",
     # Test for https://github.com/bazelbuild/rules_rust/issues/3626
@@ -302,15 +306,22 @@ crate.annotation(
 
 ### Fix -sys crates
 include("//:3rd_party/bzip2-sys/include.MODULE.bazel")
+
 include("//:3rd_party/glib-sys/include.MODULE.bazel")
+
 include("//:3rd_party/libssh2-sys/include.MODULE.bazel")
+
 include("//:3rd_party/lzma-sys/include.MODULE.bazel")
+
 include("//:3rd_party/libudev-sys/include.MODULE.bazel")
+
 include("//:3rd_party/apriltag-sys/include.MODULE.bazel")
+
 include("//:3rd_party/zstd-sys/include.MODULE.bazel")
 
-# TODO(zbarsky): alsa-sys is not curently tested, fix it
+# TODO(zbarsky): alsa-sys is not currently tested, fix it
 include("//:3rd_party/alsa-sys/include.MODULE.bazel")
+
 include("//:3rd_party/openssl-sys/include.MODULE.bazel")
 
 single_version_override(
@@ -378,7 +389,9 @@ crate.annotation(
 )
 
 include("//:3rd_party/gdk-pixbuf-sys/include.MODULE.bazel")
+
 include("//:3rd_party/cairo-sys-rs/include.MODULE.bazel")
+
 include("//:3rd_party/atk-sys/include.MODULE.bazel")
 
 crate.annotation(
@@ -388,14 +401,9 @@ crate.annotation(
 
 bazel_dep(name = "mimalloc", version = "2.2.4.bcr.1")
 
-"""
-ERROR: /Users/dzbarsky/Library/Caches/bazel/_bazel_dzbarsky/16a3c4547ef278628dec1184581db8ea/external/mimalloc+/BUILD.bazel:77:18: Linking external/mimalloc+/libmimalloc-override.so failed: (Exit 1): clang++ failed: error executing CppLink command (from cc_shared_library rule target @@mimalloc+//:mimalloc-override) external/llvm++http_archive+llvm-toolchain-minimal-21.1.8-linux-amd64/bin/clang++ -target aarch64-w64-windows-gnu '--sysroot=/dev/null' '--unwindlib=none' -nostdlib++ ... (remaining 52 arguments skipped)
-clang++: error: no such file or directory: 'psapi.lib'
-clang++: error: no such file or directory: 'shell32.lib'
-clang++: error: no such file or directory: 'user32.lib'
-clang++: error: no such file or directory: 'advapi32.lib'
-clang++: error: no such file or directory: 'bcrypt.lib'
-"""
+# ERROR: .../mimalloc+/BUILD.bazel:77:18: Linking mimalloc-override.so failed
+# clang++ -target aarch64-w64-windows-gnu failed: no such file or directory for
+# psapi.lib, shell32.lib, user32.lib, advapi32.lib, bcrypt.lib
 #crate.annotation(
 #    crate = "libmimalloc-sys",
 #    gen_build_script = "off",
@@ -405,7 +413,9 @@ clang++: error: no such file or directory: 'bcrypt.lib'
 inject_repo(crate, "mimalloc")
 
 include("//:3rd_party/libz-sys/include.MODULE.bazel")
+
 include("//:3rd_party/libgit2-sys/include.MODULE.bazel")
+
 include("//:3rd_party/coreaudio-sys/include.MODULE.bazel")
 
 # TODO(zbarsky): fix this for realz

--- a/test/toolchain_opt_level/BUILD.bazel
+++ b/test/toolchain_opt_level/BUILD.bazel
@@ -1,0 +1,20 @@
+load(":toolchain_opt_level_test.bzl", "opt_level_info")
+
+opt_level_info(
+    name = "opt_level_info",
+)
+
+genrule(
+    name = "verify_toolchain_opt_level",
+    srcs = [":opt_level_info"],
+    outs = ["verify_toolchain_opt_level.txt"],
+    cmd = """
+        grep "opt_level.opt. = 2" $(location :opt_level_info)
+        echo ok > $@
+    """,
+    # Not compatible with Windows due to the use of 'grep'
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)

--- a/test/toolchain_opt_level/toolchain_opt_level_test.bzl
+++ b/test/toolchain_opt_level/toolchain_opt_level_test.bzl
@@ -1,0 +1,15 @@
+"""Testcase to verify opt_level is correctly passed"""
+
+def _opt_level_info_impl(ctx):
+    toolchain = ctx.toolchains["@rules_rust//rust:toolchain_type"]
+    opt_mode = toolchain.compilation_mode_opts.get("opt")
+    value = opt_mode.opt_level if opt_mode else "(unset)"
+
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(out, "opt_level[opt] = " + value + "\n")
+    return [DefaultInfo(files = depset([out]))]
+
+opt_level_info = rule(
+    implementation = _opt_level_info_impl,
+    toolchains = ["@rules_rust//rust:toolchain_type"],
+)


### PR DESCRIPTION
Adds opt_level to toolchain declaration to allow overruling the defaults defined in rust_rules

Pre-commit hooks required some additional changes.