### PR TITLE
Consolidate Rust toolchain candidates

### DIFF
--- a/rs/toolchains/BUILD.bazel
+++ b/rs/toolchains/BUILD.bazel
@@ -2,6 +2,36 @@ load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
+alias(
+    name = "all_targets",
+    actual = select({
+        "@rules_rust//rust/private:bootstrapped": "@rules_rust//rust/private:bootstrapped",
+        "//conditions:default": "@rules_rust//rust/private:bootstrapping",
+    }),
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "bpf_targets",
+    actual = select({
+        "//rs/platforms/config:bpfeb-unknown-none": "//rs/platforms/config:bpfeb-unknown-none",
+        "//rs/platforms/config:bpfel-unknown-none": "//rs/platforms/config:bpfel-unknown-none",
+        # Select bpfeb-unknown-none so bpf_targets does not match any other target.
+        "//conditions:default": "//rs/platforms/config:bpfeb-unknown-none",
+    }),
+)
+
+alias(
+    name = "non_bpf_targets",
+    actual = select({
+        # Select the opposite BPF config setting so non_bpf_targets does not
+        # match either BPF target.
+        "//rs/platforms/config:bpfeb-unknown-none": "//rs/platforms/config:bpfel-unknown-none",
+        "//rs/platforms/config:bpfel-unknown-none": "//rs/platforms/config:bpfeb-unknown-none",
+        "//conditions:default": ":all_targets",
+    }),
+)
+
 bzl_library(
     name = "declare_rustc_toolchains",
     srcs = ["declare_rustc_toolchains.bzl"],

--- a/rs/toolchains/declare_rustc_toolchains.bzl
+++ b/rs/toolchains/declare_rustc_toolchains.bzl
@@ -4,11 +4,6 @@ load("//rs/platforms:triples.bzl", "ALL_TARGET_TRIPLES", "SUPPORTED_EXEC_TRIPLES
 load("//rs/private:bpf_linker_repository.bzl", "bpf_linker_binary_name", "bpf_linker_repository_name")
 load("//rs/toolchains:toolchain_utils.bzl", "sanitize_triple", "sanitize_version")
 
-_BPF_TARGET_TRIPLES = [
-    "bpfeb-unknown-none",
-    "bpfel-unknown-none",
-]
-
 def _channel(version):
     if version.startswith("nightly"):
         return "nightly"
@@ -192,40 +187,33 @@ def declare_rustc_toolchains(
             })
         )
 
-        for target_triple in targets:
-            target_key = sanitize_triple(target_triple)
-
+        for is_bpf, bootstrapping in [
+            (False, False),
+            (False, True),
+            (True, False),
+        ]:
+            target_kind = "bpf" if is_bpf else "non_bpf"
+            bootstrap_suffix = "_bootstrap" if bootstrapping else ""
+            bootstrap_setting = "@rules_rust//rust/private:" + ("bootstrapping" if bootstrapping else "bootstrapped")
+            toolchain_suffix = "_bpf" if is_bpf else bootstrap_suffix
             native.toolchain(
-                name = "{}_{}_to_{}_{}".format(exec_triple.system, exec_triple.arch, target_key, version_key),
+                name = "{}_{}_to_{}_targets_{}{}".format(
+                    exec_triple.system,
+                    exec_triple.arch,
+                    target_kind,
+                    version_key,
+                    bootstrap_suffix,
+                ),
                 exec_compatible_with = [
                     "@platforms//os:" + exec_triple.system,
                     "@platforms//cpu:" + exec_triple.arch,
                 ],
-                target_compatible_with = triple_to_rust_constraint_set(target_triple),
                 target_settings = [
-                    "@rules_rust//rust/private:bootstrapped",
+                    "@rules_rs//rs/toolchains:bpf_targets" if is_bpf else "@rules_rs//rs/toolchains:non_bpf_targets",
+                    bootstrap_setting,
                     "@rules_rust//rust/toolchain/channel:" + channel,
                 ],
-                toolchain = rust_toolchain_name + ("_bpf" if target_triple in _BPF_TARGET_TRIPLES else ""),
-                toolchain_type = "@rules_rust//rust:toolchain_type",
-                visibility = ["//visibility:public"],
-            )
-
-            if target_triple in _BPF_TARGET_TRIPLES:
-                continue
-
-            native.toolchain(
-                name = "{}_{}_to_{}_{}_bootstrap".format(exec_triple.system, exec_triple.arch, target_key, version_key),
-                exec_compatible_with = [
-                    "@platforms//os:" + exec_triple.system,
-                    "@platforms//cpu:" + exec_triple.arch,
-                ],
-                target_compatible_with = triple_to_rust_constraint_set(target_triple),
-                target_settings = [
-                    "@rules_rust//rust/private:bootstrapping",
-                    "@rules_rust//rust/toolchain/channel:" + channel,
-                ],
-                toolchain = rust_toolchain_name + "_bootstrap",
+                toolchain = rust_toolchain_name + toolchain_suffix,
                 toolchain_type = "@rules_rust//rust:toolchain_type",
                 visibility = ["//visibility:public"],
             )


### PR DESCRIPTION
## Summary

Declare normal, bootstrap, and BPF compiler candidates per execution triple.

Bazel 9.0.0 fresh-server analysis of `//:target_triple_constraints_test` with `--nobuild --jobs=1`:

| Metric | `main` | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Compiler candidates | 1,188 | 18 | 98.5% |
| Package targets | 1,267 | 97 | 92.3% |
| Configured targets | 662,761 | 483,147 | 27.1% |
| Mean elapsed time | 25.091 s | 24.481 s | 2.4% |
| Mean heap after GC | 694.0 MB | 547.7 MB | 21.1% |
