### PR TITLE
Add crate_name and edition to DEP_DATA and expose helpers in defs.bzl

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -571,6 +571,20 @@ def aliases(package_name = None):
 
     return dep_data["aliases"]
 
+def crate_name(package_name = None):
+    dep_data = DEP_DATA.get(package_name or native.package_name())
+    if not dep_data:
+        return None
+
+    return dep_data["crate_name"]
+
+def edition(package_name = None):
+    dep_data = DEP_DATA.get(package_name or native.package_name())
+    if not dep_data:
+        return None
+
+    return dep_data["edition"]
+
 def all_crate_deps(
         normal = False,
         normal_dev = False,

--- a/rs/private/cargo_workspace_graph.bzl
+++ b/rs/private/cargo_workspace_graph.bzl
@@ -760,10 +760,12 @@ def workspace_dep_data(
             "build_deps_by_platform": build_deps_by_platform,
             "crate_features": crate_features,
             "crate_features_by_platform": crate_features_by_platform,
+            "crate_name": package["name"].replace("-", "_"),
             "deps": deps,
             "deps_by_platform": deps_by_platform,
             "dev_deps": dev_deps,
             "dev_deps_by_platform": dev_deps_by_platform,
+            "edition": package.get("edition", "2015"),
             "shared_libraries": shared_libraries,
         }
 


### PR DESCRIPTION
Macro callers can now query a workspace crate's name and Rust edition via the generated crate_name() and edition() functions, consistent with how aliases() works.