### PR TITLE
rs: add rules_rust_bindgen extension

### DIFF
--- a/rs/rules_rust_bindgen.bzl
+++ b/rs/rules_rust_bindgen.bzl
@@ -1,0 +1,61 @@
+"""Module extension that provisions the rules_rust_bindgen repository."""
+
+def _rules_rust_bindgen_repo_impl(rctx):
+    rctx.file("BUILD.bazel", """\
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "defs.bzl",
+])
+
+alias(
+    name = "toolchain_type",
+    actual = "@rules_rust//extensions/bindgen:toolchain_type",
+)
+
+bzl_library(
+    name = "bzl_lib",
+    srcs = [
+        "defs.bzl",
+    ],
+    deps = [
+        "@rules_rust//extensions/bindgen:bzl_lib",
+    ],
+)
+""")
+
+    rctx.file("defs.bzl", """\
+load(
+    "@rules_rust//extensions/bindgen:defs.bzl",
+    _rust_bindgen = "rust_bindgen",
+    _rust_bindgen_library = "rust_bindgen_library",
+    _rust_bindgen_toolchain = "rust_bindgen_toolchain",
+)
+
+rust_bindgen = _rust_bindgen
+rust_bindgen_library = _rust_bindgen_library
+rust_bindgen_toolchain = _rust_bindgen_toolchain
+""")
+
+    return rctx.repo_metadata(reproducible = True)
+
+_rules_rust_bindgen_repo = repository_rule(
+    implementation = _rules_rust_bindgen_repo_impl,
+)
+
+def _rules_rust_bindgen_impl(mctx):
+    _rules_rust_bindgen_repo(
+        name = "rules_rust_bindgen",
+    )
+
+    return mctx.extension_metadata(
+        root_module_direct_deps = ["rules_rust_bindgen"],
+        root_module_direct_dev_deps = [],
+        reproducible = True,
+    )
+
+rules_rust_bindgen = module_extension(
+    implementation = _rules_rust_bindgen_impl,
+)


### PR DESCRIPTION
> [!NOTE]
> This PR depends on the changes in https://github.com/hermeticbuild/rules_rust/pull/31

This is basically a shim around the underlying extension in hermeticbuild/rules_rust, and notably _we do not provide a default toolchain for bindgen_ -- users are expected to provide their own.

This can be easily done if using hermeticbuild/hermetic-llvm, as it provides targets for clang, libclang and libstdcxx.

---

I provide the toolchain myself via a `crate` extension for `bindgen-cli` and then `@llvm` for the llvm bits:

```bzl
load("@rules_rust_bindgen//:defs.bzl", "rust_bindgen_toolchain")

package(default_visibility = ["//visibility:public"])

toolchain(
    name           = "toolchain",
    toolchain      = "bindgen_toolchain_impl",
    toolchain_type = "@rules_rust_bindgen//:toolchain_type",
)

rust_bindgen_toolchain(
    name      = "bindgen_toolchain_impl",
    bindgen   = ":bindgen",
    clang     = "@llvm-project//clang:clang",
    libclang  = "@llvm-project//clang:libclang",
    libstdcxx = ":libstdcxx",
)

alias(
    name = "bindgen",
    actual = "@bindgen_toolchain_tools//:bindgen-cli__bindgen",
)

cc_import(
    name            = "libstdcxx",
    hdrs            = ["@llvm//runtimes/libstdcxx:headers_include_search_directory"],
    shared_library  = "@llvm//runtimes/libstdcxx:libstdcxx.shared",
    visibility      = ["//visibility:public"],
)
```

<details>
<summary>@bindgen_toolchain_tools//:bindgen-cli__bindgen</summary>

```bzl
# bindgen.MODULE.bazel
package = "<label of parent package where this MODULE.bazel is>"

bindgen_toolchain_tools = use_extension("@rules_rs//rs:extensions.bzl", "crate")

bindgen_toolchain_tools.annotation(
    crate = "bindgen-cli",
    gen_binaries = ["bindgen"],
)

bindgen_toolchain_tools.from_cargo(
    name = "bindgen_toolchain_tools",
    cargo_lock = package + ":Cargo.lock",
    cargo_toml = package + ":Cargo.toml",
    platform_triples = ["..."],
)

use_repo(
    bindgen_toolchain_tools,
    "bindgen_toolchain_tools",
)
```

```toml
# Cargo.toml
[package]
name    = "bindgen-tool"
version = "1.0.0"
edition = "2021"

[lib]
crate-type = ["lib"]
path = "empty.rs" # needed to satisfy @rules_rs

[dependencies.bindgen]
version  = "0.72"
features = [
  "runtime",
]

[dependencies.bindgen-cli]
version  = "0.72"
features = [
  "runtime",
]

[dependencies.clang-sys]
git = "https://github.com/KyleMayes/clang-sys"
rev = "a76fd89f1800155e06f99ec5e200a02aadb49e3f"
features = [
  "clang_20_0",
  "runtime",
]

[patch.crates-io]
clang-sys = { git = "https://github.com/KyleMayes/clang-sys", rev = "a76fd89f1800155e06f99ec5e200a02aadb49e3f" }
```
</details>

See https://bazelbuild.slack.com/archives/C05UNC5AANQ/p1782926171232299?thread_ts=1782822956.695739&cid=C05UNC5AANQ for the context of where this is coming from.