### PR TITLE
Add support for per-platform aliases

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -558,6 +558,7 @@ cargo_lints(
 
     defs_bzl_contents = \
         """load(":data.bzl", "DEP_DATA")
+load("@rules_rs//rs/private:aliases.bzl", _aliases = "aliases")
 load("@rules_rs//rs/private:all_crate_deps.bzl", _all_crate_deps = "all_crate_deps")
 
 _PLATFORMS = [
@@ -569,7 +570,7 @@ def aliases(package_name = None):
     if not dep_data:
         return {{}}
 
-    return dep_data["aliases"]
+    return _aliases(dep_data, platforms = _PLATFORMS)
 
 def all_crate_deps(
         normal = False,

--- a/rs/private/aliases.bzl
+++ b/rs/private/aliases.bzl
@@ -1,0 +1,14 @@
+load(":select_utils.bzl", "compute_select_dict")
+
+def aliases(dep_data, platforms):
+    shared_aliases = dep_data["aliases"]
+    aliases_by_platform = {
+        platform: dep_data["aliases_by_platform"].get(platform, {})
+        for platform in platforms
+    }
+
+    aliases, per_platform = compute_select_dict(shared_aliases, aliases_by_platform)
+
+    branches = {platform: aliases for platform, aliases in sorted(per_platform.items())}
+    branches["//conditions:default"] = {}
+    return aliases | select(branches)

--- a/rs/private/all_crate_deps.bzl
+++ b/rs/private/all_crate_deps.bzl
@@ -1,4 +1,4 @@
-load(":select_utils.bzl", "compute_select")
+load(":select_utils.bzl", "compute_select_list")
 
 def _filter_by_prefix(deps, prefix):
     return [dep for dep in deps if dep.startswith(prefix)]
@@ -33,7 +33,7 @@ def merge_structured_dep_specs(specs, platforms, filter_prefix):
 
             existing.update(filtered)
 
-    deps, per_platform = compute_select(merged_deps, merged_by_platform)
+    deps, per_platform = compute_select_list(merged_deps, merged_by_platform)
     return sorted(deps), per_platform
 
 def all_crate_deps(

--- a/rs/private/cargo_workspace_graph.bzl
+++ b/rs/private/cargo_workspace_graph.bzl
@@ -1,7 +1,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//rs/private:cfg_parser.bzl", "cfg_matches_expr_for_cfg_attrs", "triple_to_cfg_attrs")
 load("//rs/private:resolver.bzl", "resolve")
-load("//rs/private:select_utils.bzl", "compute_select")
+load("//rs/private:select_utils.bzl", "compute_select_dict", "compute_select_list")
 load("//rs/private:semver.bzl", "select_matching_version")
 
 def platform_label(triple, use_legacy_rules_rust_platforms):
@@ -31,7 +31,22 @@ def add_to_dict(d, k, v):
 def exclude_deps_from_features(features):
     return [f for f in features if not f.startswith("dep:")]
 
-def shared_and_per_platform(platform_items, use_legacy_rules_rust_platforms):
+def _shared_and_per_platform_dict(platform_items, use_legacy_rules_rust_platforms):
+    if not platform_items:
+        return {}, {}
+
+    by_platform = {}
+    for triple, items in platform_items.items():
+        platform = platform_label(triple, use_legacy_rules_rust_platforms)
+        existing = by_platform.get(platform)
+        if existing == None:
+            by_platform[platform] = dict(items)
+        else:
+            existing.update(items)
+
+    return compute_select_dict({}, by_platform)
+
+def _shared_and_per_platform_list(platform_items, use_legacy_rules_rust_platforms):
     if not platform_items:
         return [], {}
 
@@ -44,7 +59,7 @@ def shared_and_per_platform(platform_items, use_legacy_rules_rust_platforms):
         else:
             existing.update(items)
 
-    items, per_platform = compute_select([], by_platform)
+    items, per_platform = compute_select_list([], by_platform)
     return sorted(items), per_platform
 
 def select_items(items):
@@ -712,12 +727,6 @@ def workspace_dep_data(
 
             is_self_dep = dep_path and normalize_path(dep_path) == package_manifest_dir
 
-            if not is_self_dep:
-                if dep.get("rename"):
-                    aliases[bazel_target] = dep["rename"].replace("-", "_")
-                elif dep_path:
-                    aliases[bazel_target] = dep["name"].replace("-", "_")
-
             target = dep.get("target")
             match_info = cfg_match_info_for_target(target, platform_cfg_attrs, cfg_match_cache)
             match = match_info.matches
@@ -740,6 +749,11 @@ def workspace_dep_data(
                 if is_self_dep:
                     continue
 
+                if dep.get("rename"):
+                    aliases.setdefault(triple, {})[bazel_target] = dep["rename"].replace("-", "_")
+                elif dep_path:
+                    aliases.setdefault(triple, {})[bazel_target] = dep["name"].replace("-", "_")
+
                 target_deps[triple].add(bazel_target)
 
         if feature_resolutions:
@@ -748,13 +762,15 @@ def workspace_dep_data(
 
         bazel_package = paths.join(workspace_package, package_dir) if package_dir else workspace_package
 
-        crate_features, crate_features_by_platform = shared_and_per_platform(crate_features, use_legacy_rules_rust_platforms)
-        deps, deps_by_platform = shared_and_per_platform(deps, use_legacy_rules_rust_platforms)
-        build_deps, build_deps_by_platform = shared_and_per_platform(build_deps, use_legacy_rules_rust_platforms)
-        dev_deps, dev_deps_by_platform = shared_and_per_platform(dev_deps, use_legacy_rules_rust_platforms)
+        aliases, aliases_by_platform = _shared_and_per_platform_dict(aliases, use_legacy_rules_rust_platforms)
+        crate_features, crate_features_by_platform = _shared_and_per_platform_list(crate_features, use_legacy_rules_rust_platforms)
+        deps, deps_by_platform = _shared_and_per_platform_list(deps, use_legacy_rules_rust_platforms)
+        build_deps, build_deps_by_platform = _shared_and_per_platform_list(build_deps, use_legacy_rules_rust_platforms)
+        dev_deps, dev_deps_by_platform = _shared_and_per_platform_list(dev_deps, use_legacy_rules_rust_platforms)
 
         dep_data[bazel_package] = {
             "aliases": aliases,
+            "aliases_by_platform": aliases_by_platform,
             "binaries": binaries,
             "build_deps": build_deps,
             "build_deps_by_platform": build_deps_by_platform,

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages")
+load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "platform_label", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages", "workspace_dep_data")
+load(":cfg_parser.bzl", "triple_to_cfg_attrs")
 
 def _select_package_fq_dep_uses_package_name_impl(ctx):
     env = unittest.begin(ctx)
@@ -265,6 +266,64 @@ def _resolve_package_facts_attaches_feature_resolutions_impl(ctx):
 
 resolve_package_facts_attaches_feature_resolutions_test = unittest.make(_resolve_package_facts_attaches_feature_resolutions_impl)
 
+def _workspace_dep_data_scopes_first_party_aliases_by_platform_impl(ctx):
+    env = unittest.begin(ctx)
+
+    platform_triples = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+    platform_cfg_attrs = [triple_to_cfg_attrs(triple) for triple in platform_triples]
+
+    dep_data = workspace_dep_data(
+        cargo_metadata = {
+            "packages": [
+                {
+                    "name": "app",
+                    "version": "0.1.0",
+                    "manifest_path": "/repo/app/Cargo.toml",
+                    "dependencies": [
+                        {
+                            "name": "netdep",
+                            "kind": "normal",
+                            "path": "/repo/netdep",
+                            "bazel_target": "//netdep",
+                            "target": "cfg(target_os = \"linux\")",
+                        },
+                        {
+                            "name": "macdep",
+                            "kind": "normal",
+                            "path": "/repo/macdep",
+                            "bazel_target": "//macdep",
+                            "target": "cfg(target_os = \"macos\")",
+                        },
+                    ],
+                },
+            ],
+        },
+        feature_resolutions_by_fq_crate = {},
+        platform_triples = platform_triples,
+        platform_cfg_attrs = platform_cfg_attrs,
+        cfg_match_cache = {},
+        repo_root = "/repo",
+        workspace_package = "",
+        use_legacy_rules_rust_platforms = False,
+    )
+
+    app = dep_data["app"]
+    linux_platform = platform_label("x86_64-unknown-linux-gnu", False)
+    darwin_platform = platform_label("aarch64-apple-darwin", False)
+
+    # No first-party alias is shared across all platforms.
+    asserts.equals(env, {}, app["aliases"])
+
+    # Each alias only appears for the platform that actually depends on it.
+    asserts.equals(env, {
+        linux_platform: {"//netdep": "netdep"},
+        darwin_platform: {"//macdep": "macdep"},
+    }, app["aliases_by_platform"])
+
+    return unittest.end(env)
+
+workspace_dep_data_scopes_first_party_aliases_by_platform_test = unittest.make(_workspace_dep_data_scopes_first_party_aliases_by_platform_impl)
+
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
@@ -274,4 +333,5 @@ def cargo_workspace_graph_tests():
         select_package_fq_dep_uses_package_name_test,
         select_package_fq_dep_uses_req_for_duplicate_versions_test,
         split_lockfile_packages_finds_local_package_paths_test,
+        workspace_dep_data_scopes_first_party_aliases_by_platform_test,
     )

--- a/rs/private/repository_utils.bzl
+++ b/rs/private/repository_utils.bzl
@@ -1,4 +1,4 @@
-load(":select_utils.bzl", "compute_select")
+load(":select_utils.bzl", "compute_select_list")
 load(":semver.bzl", "parse_full_version")
 
 # Bazel 8 does not define attr.label_list_dict.
@@ -22,7 +22,7 @@ def render_select(non_platform_items, platform_items, use_legacy_rules_rust_plat
         platform: [str(item) for item in items]
         for platform, items in platform_items.items()
     }
-    common_items, branches = compute_select(non_platform_items, platform_items)
+    common_items, branches = compute_select_list(non_platform_items, platform_items)
     common_items = list(common_items)
 
     if not branches:
@@ -207,7 +207,7 @@ _RUST_CRATE_MACRO_CALL = """{indent}rust_crate(
 def render_rust_crate_call(attr, values, bazel_metadata = {}, extra_deps = "", indent = "", skip_deps_verification = False):
     # We keep conditional_crate_features unrendered here because it must be treated specially for build scripts.
     # See `rust_crate.bzl` for details.
-    crate_features, conditional_crate_features = compute_select(
+    crate_features, conditional_crate_features = compute_select_list(
         _exclude_deps_from_features(attr.crate_features),
         {platform: _exclude_deps_from_features(features) for platform, features in attr.crate_features_select.items()},
     )

--- a/rs/private/select_utils.bzl
+++ b/rs/private/select_utils.bzl
@@ -1,4 +1,50 @@
-def compute_select(non_platform_items, platform_items):
+def compute_select_dict(non_platform_items, platform_items):
+    if not platform_items:
+        return non_platform_items, {}
+
+    item_values = platform_items.values()
+    common_keys = set(item_values[0].keys())
+
+    # FIXME: Currently we override values if the same value exists in
+    #        both platform and non-platform items (or in multiple platforms).
+    #        We should instead keep them in selects if they are different instead
+    #        of merging.
+    all_values = {key: item_values[0][key] for key in common_keys}
+
+    for values in item_values[1:]:
+        common_keys.intersection_update(values.keys())
+        all_values = {
+            key: all_values.get(key, values[key])
+            for key in common_keys
+        }
+        if not common_keys:
+            break
+
+    common_keys.update(non_platform_items.keys())
+    all_values.update(non_platform_items)
+
+    branches = {}
+    for platform, items in platform_items.items():
+        keys = set(items.keys())
+        keys.difference_update(non_platform_items.keys())
+        keys.difference_update(common_keys)
+        if keys:
+            branches[platform] = sorted(keys)
+            for key in keys:
+                all_values[key] = items[key]
+
+    return {
+        key: all_values[key]
+        for key in common_keys
+    }, {
+        platform: {
+            key: all_values[key]
+            for key in keys
+        }
+        for platform, keys in branches.items()
+    }
+
+def compute_select_list(non_platform_items, platform_items):
     if not platform_items:
         return non_platform_items, {}
 


### PR DESCRIPTION
Aliases for first-party crates were unconditionally added to the shared alias data for a workspace crate.  This does not work if a first-party dependency should only be added for specific targets (e.g. a tool can make network connections using a first-party dependency but only on certain platforms, and does not use the dependency crate otherwise).

This change makes it so that we only add an alias for a first-party crate if it would also appear as a dependency for that specific target. Dependency data now has a new field called `aliases_by_platform`, and the generated aliases() helper emits a select expression if there are platform-specific aliases.