### PR TITLE
Fix Miri flags and expand BCR Bazel matrix

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "."
   matrix:
     platform: ["debian10", "macos", "ubuntu2004"]
-    bazel: ["8.5.0"]
+    bazel: ["8.5.0", "9.x", "rolling"]
   tasks:
     run_tests:
       name: "Run tests"

--- a/rs/experimental/miri/private/compile.bzl
+++ b/rs/experimental/miri/private/compile.bzl
@@ -312,8 +312,6 @@ def _miri_host_crate_info_dict(crate, output, deps, proc_macro_deps):
 
 def _miri_host_compile_action(ctx, crate, toolchain, rust_toolchain, deps, proc_macro_deps):
     output = _host_output(ctx, crate)
-    rust_flags = ctx.actions.args()
-    rust_flags.add_all([toolchain.host_miri_sysroot], format_each = "--sysroot=%s", expand_directories = False)
 
     result = rustc_compile(
         ctx = ctx,
@@ -338,7 +336,7 @@ def _miri_host_compile_action(ctx, crate, toolchain, rust_toolchain, deps, proc_
         mnemonic = "MiriHostRustc",
         output_hash = _host_output_hash(ctx, crate),
         progress_message = "Compiling Rust host dependency for Miri %{label}",
-        rust_flags = rust_flags,
+        rust_flags = [("--sysroot=%s", toolchain.host_miri_sysroot)],
         skip_expanding_rustc_env = True,
     )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -339,10 +339,8 @@ genrule(
 
 filegroup(
     name = "all_builds",
-    testonly = True,
     srcs = ["@%s//:_workspace_deps" % test for test in TESTS] + [
         ":aws_lc_openssl",
-        ":aws_lc_sys_test",
         ":rust_binary",
         ":verify_self_dev_dependency_feature_present",
         ":verify_self_dev_dependency_no_self_alias",
@@ -391,7 +389,6 @@ LINUX_GNU_PLATFORMS = {
 [
     platform_transition_filegroup(
         name = "all_builds_" + platform,
-        testonly = True,
         srcs = ["all_builds"],
         target_platform = LINUX_GNU_PLATFORMS.get(
             platform,


### PR DESCRIPTION
`miri_compile_aspect` passed a Bazel `Args` object to `rules_rust`'s `rustc_compile`, but `rustc_compile` now concatenates profiling flags and requires its documented list form. Pass the host Miri sysroot as a `(format_string, File)` list entry so the sysroot remains path-mappable, and keep `aws_lc_sys_test` out of the cross-platform `all_builds` filegroup because Bazel cannot resolve the default test execution toolchain under those target transitions.

The BCR presubmit matrix now covers Bazel 8.5.0, Bazel 9.x, and `rolling`, which is the Bazel 10 prerelease track until Bazel 10 has an LTS binary.

Validated all four Miri tests with Bazel 8.7.0 and Bazel 9.0.0, and built the Windows gnullvm x86-64 and Linux arm64 `all_builds` transition targets with remote execution.
