### PR TITLE
feat: Add support for Rust's stable RV32IMAC target

### DIFF
--- a/rs/platforms/constraints/BUILD.bazel
+++ b/rs/platforms/constraints/BUILD.bazel
@@ -20,6 +20,26 @@ constraint_value(
 )
 
 constraint_setting(
+    # Bare-metal RISC-V target triples can share the same Bazel CPU and OS
+    # constraints while enabling different ISA extensions. Default to the
+    # previously supported RV32IMC target so existing custom riscv32/none
+    # platforms continue to resolve to the same Rust toolchain.
+    name = "riscv_isa",
+    default_constraint_value = "rv32imc",
+)
+
+constraint_value(
+    name = "rv32imc",
+    constraint_setting = "riscv_isa",
+)
+
+constraint_value(
+    # ESP32-C6 and ESP32-H2 use the atomic-capable RV32IMAC target.
+    name = "rv32imac",
+    constraint_setting = "riscv_isa",
+)
+
+constraint_setting(
     # Disambiguates ARM soft-float vs hard-float target triples that otherwise
     # project to identical constraint sets (e.g. arm-unknown-linux-gnueabi vs
     # ...gnueabihf, or aarch64-unknown-none vs ...none-softfloat). Defaults to

--- a/rs/platforms/triples.bzl
+++ b/rs/platforms/triples.bzl
@@ -4,6 +4,11 @@ load(
     _triple_to_constraint_set = "triple_to_constraint_set",
 )
 
+_RISCV_ISA_CONSTRAINTS = {
+    "riscv32imac-unknown-none-elf": "@rules_rs//rs/platforms/constraints:rv32imac",
+    "riscv32imc-unknown-none-elf": "@rules_rs//rs/platforms/constraints:rv32imc",
+}
+
 def triple_to_rust_constraint_set(target_triple):
     constraints = _triple_to_constraint_set(target_triple)
     t = triple(target_triple)
@@ -21,6 +26,10 @@ def triple_to_rust_constraint_set(target_triple):
         # https://github.com/rust-lang/rust/blob/c935696dd07ca51e6fba2f6579919eea2a50863b/compiler/rustc_target/src/spec/base/windows_gnu.rs#L44
         if t.abi in ("gnu", "gnullvm"):
             constraints.append("@llvm//constraints/windows/crt:msvcrt")
+
+    riscv_isa_constraint = _RISCV_ISA_CONSTRAINTS.get(target_triple)
+    if riscv_isa_constraint:
+        constraints.append(riscv_isa_constraint)
 
     if target_triple.endswith("eabihf") or target_triple == "aarch64-unknown-none":
         constraints.append("@rules_rs//rs/platforms/constraints:hardfloat")
@@ -134,7 +143,7 @@ SUPPORTED_TIER_1_AND_2_TRIPLES = [
     #"nvptx64-nvidia-cuda",             # * –emit=asm generates PTX code that runs on NVIDIA GPUs
     # "riscv32i-unknown-none-elf",       # * Bare RISC-V (RV32I ISA)
     # "riscv32im-unknown-none-elf",      # * Bare RISC-V (RV32IM ISA)
-    # "riscv32imac-unknown-none-elf",    # * Bare RISC-V (RV32IMAC ISA)
+    "riscv32imac-unknown-none-elf",  # * Bare RISC-V (RV32IMAC ISA)
     # "riscv32imafc-unknown-none-elf",   # * Bare RISC-V (RV32IMAFC ISA)
     "riscv32imc-unknown-none-elf",  # * Bare RISC-V (RV32IMC ISA)
     "riscv64gc-unknown-linux-musl",  # ✓ RISC-V Linux (kernel 4.20+, musl 1.2.5)

--- a/rs/toolchains/declare_rustc_toolchains.bzl
+++ b/rs/toolchains/declare_rustc_toolchains.bzl
@@ -65,6 +65,7 @@ def declare_rustc_toolchains(
         rustc_repo_label = "@rustc_{}_{}//:".format(triple_suffix, version_key)
         cargo_repo_label = "@cargo_{}_{}//:".format(triple_suffix, version_key)
         clippy_repo_label = "@clippy_{}_{}//:".format(triple_suffix, version_key)
+        lld_label = rustc_repo_label + "rust-lld"
 
         rust_toolchain_name = "{}_{}_{}_rust_toolchain".format(
             exec_triple.system,
@@ -102,8 +103,10 @@ def declare_rustc_toolchains(
             llvm_cov = "@llvm//tools:llvm-cov",
             llvm_profdata = "@llvm//tools:llvm-profdata",
             linker = select({
-                "@platforms//cpu:wasm32": "{}rust-lld".format(rustc_repo_label),
-                "@platforms//cpu:wasm64": "{}rust-lld".format(rustc_repo_label),
+                "@rules_rs//rs/platforms/config:riscv32imac-unknown-none-elf": lld_label,
+                "@rules_rs//rs/platforms/config:riscv32imc-unknown-none-elf": lld_label,
+                "@platforms//cpu:wasm32": lld_label,
+                "@platforms//cpu:wasm64": lld_label,
                 "//conditions:default": None,
             }),
             linker_type = "direct",


### PR DESCRIPTION
This change:

- Adds the target to the supported matrix.
- Distinguishes RV32IMAC from RV32IMC with an ISA constraint.
- Keeps RV32IMC as the default for compatibility.
- Uses the Rust distribution's hermetic `rust-lld`.

While this is important to me for my current ESP32-C6 project, it will also benefit ESP32-H2 and other bare-metal devices using this standard Rust target.

## Validation

Validated with `rules_rs` v0.0.96 and Rust 1.96.1 by building a statically linked ESP32-C6 firmware ELF.

The related RISC-V `target_arch` normalization is proposed separately as an independent prerequisite.

