### PR TITLE
fix: expand registry {prefix} placeholder to the directory prefix only

### DIFF
--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -135,7 +135,10 @@ bzl_library(
     name = "registry_config_repository",
     srcs = ["registry_config_repository.bzl"],
     visibility = ["//rs:__subpackages__"],
-    deps = [":cargo_credentials"],
+    deps = [
+        ":cargo_credentials",
+        ":registry_utils",
+    ],
 )
 
 bzl_library(

--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -7,6 +7,7 @@ load(":bpf_linker_repository_test.bzl", "bpf_linker_repository_tests")
 load(":cargo_workspace_graph_test.bzl", "cargo_workspace_graph_tests")
 load(":cfg_parser_test.bzl", "cfg_parser_tests")
 load(":lint_flags_test.bzl", "lint_flags_tests")
+load(":registry_utils_test.bzl", "registry_utils_tests")
 load(":semver_test.bzl", "semver_select_tests")
 
 bool_setting(
@@ -32,6 +33,8 @@ cargo_workspace_graph_tests()
 cfg_parser_tests()
 
 lint_flags_tests()
+
+registry_utils_tests()
 
 semver_select_tests()
 
@@ -145,6 +148,15 @@ bzl_library(
     name = "registry_utils",
     srcs = ["registry_utils.bzl"],
     visibility = ["//rs:__subpackages__"],
+)
+
+bzl_library(
+    name = "registry_utils_test",
+    srcs = ["registry_utils_test.bzl"],
+    deps = [
+        ":registry_utils",
+        "@bazel_skylib//lib:unittest",
+    ],
 )
 
 bzl_library(

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages")
+load(":registry_utils.bzl", "registry_download_url")
 
 def _select_package_fq_dep_uses_package_name_impl(ctx):
     env = unittest.begin(ctx)
@@ -265,11 +266,35 @@ def _resolve_package_facts_attaches_feature_resolutions_impl(ctx):
 
 resolve_package_facts_attaches_feature_resolutions_test = unittest.make(_resolve_package_facts_attaches_feature_resolutions_impl)
 
+def _registry_download_url_uses_directory_prefix_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "https://registry.example/My/Cr/my/cr/MyCrate-1.2.3-deadbeef.crate",
+        registry_download_url(
+            {"dl": "https://registry.example/{prefix}/{lowerprefix}/{crate}-{version}-{sha256-checksum}.crate"},
+            "MyCrate",
+            "1.2.3",
+            "deadbeef",
+        ),
+    )
+    for crate, prefix in [("a", "1"), ("ab", "2"), ("abc", "3/a"), ("cargo", "ca/rg")]:
+        asserts.equals(
+            env,
+            "https://registry.example/" + prefix,
+            registry_download_url({"dl": "https://registry.example/{prefix}"}, crate, "1.0.0", "checksum"),
+        )
+    return unittest.end(env)
+
+registry_download_url_uses_directory_prefix_test = unittest.make(_registry_download_url_uses_directory_prefix_impl)
+
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
         cargo_toml_dependencies_handles_workspace_inheritance_test,
         cargo_toml_dependencies_normalizes_dependency_specs_test,
+        registry_download_url_uses_directory_prefix_test,
         resolve_package_facts_attaches_feature_resolutions_test,
         select_package_fq_dep_uses_package_name_test,
         select_package_fq_dep_uses_req_for_duplicate_versions_test,

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -1,6 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages")
-load(":registry_utils.bzl", "registry_download_url")
 
 def _select_package_fq_dep_uses_package_name_impl(ctx):
     env = unittest.begin(ctx)
@@ -266,35 +265,11 @@ def _resolve_package_facts_attaches_feature_resolutions_impl(ctx):
 
 resolve_package_facts_attaches_feature_resolutions_test = unittest.make(_resolve_package_facts_attaches_feature_resolutions_impl)
 
-def _registry_download_url_uses_directory_prefix_impl(ctx):
-    env = unittest.begin(ctx)
-
-    asserts.equals(
-        env,
-        "https://registry.example/My/Cr/my/cr/MyCrate-1.2.3-deadbeef.crate",
-        registry_download_url(
-            {"dl": "https://registry.example/{prefix}/{lowerprefix}/{crate}-{version}-{sha256-checksum}.crate"},
-            "MyCrate",
-            "1.2.3",
-            "deadbeef",
-        ),
-    )
-    for crate, prefix in [("a", "1"), ("ab", "2"), ("abc", "3/a"), ("cargo", "ca/rg")]:
-        asserts.equals(
-            env,
-            "https://registry.example/" + prefix,
-            registry_download_url({"dl": "https://registry.example/{prefix}"}, crate, "1.0.0", "checksum"),
-        )
-    return unittest.end(env)
-
-registry_download_url_uses_directory_prefix_test = unittest.make(_registry_download_url_uses_directory_prefix_impl)
-
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
         cargo_toml_dependencies_handles_workspace_inheritance_test,
         cargo_toml_dependencies_normalizes_dependency_specs_test,
-        registry_download_url_uses_directory_prefix_test,
         resolve_package_facts_attaches_feature_resolutions_test,
         select_package_fq_dep_uses_package_name_test,
         select_package_fq_dep_uses_req_for_duplicate_versions_test,

--- a/rs/private/crate_repository.bzl
+++ b/rs/private/crate_repository.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:cache.bzl", "get_default_canonical_id")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 load(":cargo_credentials.bzl", "load_cargo_credentials", "registry_auth_headers")
-load(":registry_utils.bzl", "sharded_path")
+load(":registry_utils.bzl", "registry_download_url_from_template")
 load(":repository_utils.bzl", "cargo_build_file_values", "common_attrs", "render_build_file_content")
 load(":toml2json.bzl", "run_toml2json")
 
@@ -41,13 +41,7 @@ def _crate_repository_impl(rctx):
 
     dl = rctx.read(rctx.attr.registry_config)
 
-    url = dl.format(**{
-        "crate": crate_name,
-        "version": version,
-        "prefix": sharded_path(crate_name),
-        "lowerprefix": sharded_path(crate_name.lower()),
-        "sha256-checksum": sha256,
-    })
+    url = registry_download_url_from_template(dl, crate_name, version, sha256)
 
     rctx.download_and_extract(
         url,

--- a/rs/private/registry_config_repository.bzl
+++ b/rs/private/registry_config_repository.bzl
@@ -1,4 +1,5 @@
 load(":cargo_credentials.bzl", "load_cargo_credentials", "registry_auth_headers")
+load(":registry_utils.bzl", "registry_download_template")
 
 def _registry_config_repository_impl(rctx):
     # TODO(zbarsky): Is there a better way than fetching this in every crate repository?
@@ -16,17 +17,7 @@ def _registry_config_repository_impl(rctx):
         headers = headers,
     )
 
-    dl = json.decode(rctx.read("config.json"))["dl"]
-    if not (
-        "{crate}" in dl or
-        "{version}" in dl or
-        "{sha256-checksum}" in dl or
-        "{prefix}" in dl or
-        "{lowerprefix}" in dl
-    ):
-        dl += "/{crate}/{version}/download"
-
-    rctx.file("dl", dl)
+    rctx.file("dl", registry_download_template(json.decode(rctx.read("config.json"))))
     rctx.file("BUILD.bazel", "exports_files(['dl'])")
 
     # Registry config can change upstream, so this repository is intentionally not reproducible.

--- a/rs/private/registry_utils.bzl
+++ b/rs/private/registry_utils.bzl
@@ -1,19 +1,80 @@
 CRATES_IO_REGISTRY = "sparse+https://index.crates.io/"
 
+def registry_download_template(config):
+    """Returns the crate download template from a registry config.
+
+    Args:
+        config: Decoded registry config.json object.
+
+    Returns:
+        A download URL template using Cargo's registry placeholders.
+    """
+    dl = config["dl"]
+    if not (
+        "{crate}" in dl or
+        "{version}" in dl or
+        "{sha256-checksum}" in dl or
+        "{prefix}" in dl or
+        "{lowerprefix}" in dl
+    ):
+        dl += "/{crate}/{version}/download"
+    return dl
+
+def registry_download_url_from_template(template, crate, version, checksum):
+    """Expands a registry download template for one crate.
+
+    Args:
+        template: Download URL template from a registry config.json.
+        crate: Published crate name.
+        version: Published crate version.
+        checksum: Registry checksum for the published archive.
+
+    Returns:
+        The archive download URL.
+    """
+    return template.format(**{
+        "crate": crate,
+        "version": version,
+        "prefix": registry_path_prefix(crate),
+        "lowerprefix": registry_path_prefix(crate.lower()),
+        "sha256-checksum": checksum,
+    })
+
+def registry_download_url(config, crate, version, checksum):
+    """Expands a registry config into the download URL for one crate."""
+    return registry_download_url_from_template(
+        registry_download_template(config),
+        crate,
+        version,
+        checksum,
+    )
+
 def registry_config_repo_name(hub_name, source):
     return hub_name + "_" + registry_repo_name(source)
 
 def registry_repo_name(source):
     return source.removeprefix("sparse+").replace(":", "_").replace("/", "_")
 
-def sharded_path(crate):
+def registry_path_prefix(crate):
+    """Returns Cargo's case-preserving registry directory prefix.
+
+    Args:
+        crate: Published crate name.
+
+    Returns:
+        The directory portion of the crate's sharded registry path.
+    """
     n = len(crate)
     if n == 0:
         fail("empty crate name")
     if n == 1:
-        return "1/" + crate
+        return "1"
     if n == 2:
-        return "2/" + crate
+        return "2"
     if n == 3:
-        return "3/%s/%s" % (crate[0], crate)
-    return "%s/%s/%s" % (crate[0:2], crate[2:4], crate)
+        return "3/%s" % crate[0]
+    return "%s/%s" % (crate[0:2], crate[2:4])
+
+def sharded_path(crate):
+    """Returns the sparse-index path containing a crate's metadata."""
+    return registry_path_prefix(crate) + "/" + crate

--- a/rs/private/registry_utils_test.bzl
+++ b/rs/private/registry_utils_test.bzl
@@ -1,0 +1,31 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":registry_utils.bzl", "registry_download_url")
+
+def _registry_download_url_uses_directory_prefix_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "https://registry.example/My/Cr/my/cr/MyCrate-1.2.3-deadbeef.crate",
+        registry_download_url(
+            {"dl": "https://registry.example/{prefix}/{lowerprefix}/{crate}-{version}-{sha256-checksum}.crate"},
+            "MyCrate",
+            "1.2.3",
+            "deadbeef",
+        ),
+    )
+    for crate, prefix in [("a", "1"), ("ab", "2"), ("abc", "3/a"), ("cargo", "ca/rg")]:
+        asserts.equals(
+            env,
+            "https://registry.example/" + prefix,
+            registry_download_url({"dl": "https://registry.example/{prefix}"}, crate, "1.0.0", "checksum"),
+        )
+    return unittest.end(env)
+
+registry_download_url_uses_directory_prefix_test = unittest.make(_registry_download_url_uses_directory_prefix_impl)
+
+def registry_utils_tests():
+    return unittest.suite(
+        "registry_utils_tests",
+        registry_download_url_uses_directory_prefix_test,
+    )


### PR DESCRIPTION
Cargo defines `{prefix}`/`{lowerprefix}` in registry `dl` templates as the sharded directory portion only, but we substituted the full sharded path including the crate name, producing broken download URLs for registries whose templates embed the crate name separately.