### PR TITLE
fix: detect proc-macro crates declared via crate-type

### DIFF
--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_rust//rust:defs.bzl", "rust_stdlib_filegroup")
 load(":all_crate_deps_test.bzl", "all_crate_deps_tests")
 load(":bindgen_test.bzl", "bindgen_tests")
 load(":bpf_linker_repository_test.bzl", "bpf_linker_repository_tests")
+load(":cargo_toml_utils_test.bzl", "cargo_toml_utils_tests")
 load(":cargo_workspace_graph_test.bzl", "cargo_workspace_graph_tests")
 load(":cfg_parser_test.bzl", "cfg_parser_tests")
 load(":lint_flags_test.bzl", "lint_flags_tests")
@@ -26,6 +27,8 @@ all_crate_deps_tests()
 bindgen_tests()
 
 bpf_linker_repository_tests()
+
+cargo_toml_utils_tests()
 
 cargo_workspace_graph_tests()
 
@@ -79,6 +82,21 @@ bzl_library(
     deps = [
         ":toml2json",
         "@bazel_lib//lib:repo_utils",
+    ],
+)
+
+bzl_library(
+    name = "cargo_toml_utils",
+    srcs = ["cargo_toml_utils.bzl"],
+    visibility = ["//rs:__subpackages__"],
+)
+
+bzl_library(
+    name = "cargo_toml_utils_test",
+    srcs = ["cargo_toml_utils_test.bzl"],
+    deps = [
+        ":cargo_toml_utils",
+        "@bazel_skylib//lib:unittest",
     ],
 )
 
@@ -149,6 +167,7 @@ bzl_library(
     srcs = ["repository_utils.bzl"],
     visibility = ["//rs:__subpackages__"],
     deps = [
+        ":cargo_toml_utils",
         ":select_utils",
         ":semver",
     ],

--- a/rs/private/cargo_toml_utils.bzl
+++ b/rs/private/cargo_toml_utils.bzl
@@ -1,0 +1,11 @@
+"""Helpers for interpreting decoded Cargo.toml manifests."""
+
+def cargo_toml_is_proc_macro(cargo_toml_json):
+    """Whether a decoded Cargo.toml declares a procedural macro library."""
+    lib = cargo_toml_json.get("lib", {})
+    crate_types = lib.get("crate-type", lib.get("crate_type", [])) or []
+    return bool(
+        lib.get("proc-macro") or
+        lib.get("proc_macro") or
+        "proc-macro" in crate_types,
+    )

--- a/rs/private/cargo_toml_utils.bzl
+++ b/rs/private/cargo_toml_utils.bzl
@@ -3,9 +3,8 @@
 def cargo_toml_is_proc_macro(cargo_toml_json):
     """Whether a decoded Cargo.toml declares a procedural macro library."""
     lib = cargo_toml_json.get("lib", {})
+    if lib.get("proc-macro") or lib.get("proc_macro"):
+        return True
+
     crate_types = lib.get("crate-type", lib.get("crate_type", [])) or []
-    return bool(
-        lib.get("proc-macro") or
-        lib.get("proc_macro") or
-        "proc-macro" in crate_types,
-    )
+    return "proc-macro" in crate_types

--- a/rs/private/cargo_toml_utils_test.bzl
+++ b/rs/private/cargo_toml_utils_test.bzl
@@ -1,0 +1,31 @@
+"""Tests for Cargo.toml manifest helpers."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":cargo_toml_utils.bzl", "cargo_toml_is_proc_macro")
+
+def _cargo_toml_is_proc_macro_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.true(env, cargo_toml_is_proc_macro({"lib": {"proc-macro": True}}))
+    asserts.true(env, cargo_toml_is_proc_macro({"lib": {"proc_macro": True}}))
+    asserts.true(env, cargo_toml_is_proc_macro({"lib": {"crate-type": ["proc-macro"]}}))
+    asserts.true(env, cargo_toml_is_proc_macro({"lib": {"crate_type": ["proc-macro"]}}))
+
+    asserts.false(env, cargo_toml_is_proc_macro({}))
+    asserts.false(env, cargo_toml_is_proc_macro({"lib": {}}))
+    asserts.false(env, cargo_toml_is_proc_macro({"lib": {"proc-macro": False}}))
+    asserts.false(env, cargo_toml_is_proc_macro({"lib": {"crate-type": ["cdylib", "rlib"]}}))
+
+    return unittest.end(env)
+
+_cargo_toml_is_proc_macro_test = unittest.make(_cargo_toml_is_proc_macro_test_impl)
+
+def cargo_toml_utils_tests():
+    _cargo_toml_is_proc_macro_test(
+        name = "cargo_toml_is_proc_macro_test",
+    )
+
+    native.test_suite(
+        name = "cargo_toml_utils_tests",
+        tests = [":cargo_toml_is_proc_macro_test"],
+    )

--- a/rs/private/repository_utils.bzl
+++ b/rs/private/repository_utils.bzl
@@ -1,3 +1,4 @@
+load(":cargo_toml_utils.bzl", "cargo_toml_is_proc_macro")
 load(":select_utils.bzl", "compute_select")
 load(":semver.bzl", "parse_full_version")
 
@@ -124,7 +125,7 @@ def cargo_build_file_values(rctx, cargo_toml, gen_binaries, package_path = "", g
             build_script = "build.rs"
 
     lib = cargo_toml.get("lib", {})
-    is_proc_macro = lib.get("proc-macro") or lib.get("proc_macro") or False
+    is_proc_macro = cargo_toml_is_proc_macro(cargo_toml)
     crate_root = (lib.get("path") or "src/lib.rs").removeprefix("./")
     has_lib = "lib" in cargo_toml or package_dir.get_child(crate_root).exists
 


### PR DESCRIPTION
A library can declare itself a proc macro with `crate-type = ["proc-macro"]` instead of `proc-macro = true`; the manifest check now handles both spellings via a shared `cargo_toml_is_proc_macro` helper.