### PR TITLE
fix: harden resolver convergence and preserve dependency facts

### DIFF
--- a/rs/private/cargo_workspace_graph.bzl
+++ b/rs/private/cargo_workspace_graph.bzl
@@ -196,6 +196,12 @@ def prepare_possible_deps(dependencies, converter = None, skip_internal_rustc_pl
         else:
             dep = dict(dep)
 
+            # Dependency features originate in persisted facts. Copy the list
+            # before adding the implicit default feature so resolution cannot
+            # mutate the cached fact in place.
+            if "features" in dep:
+                dep["features"] = list(dep["features"])
+
         if dep.get("kind") == "dev":
             continue
 

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages")
+load(":cargo_workspace_graph.bzl", "cargo_toml_dependencies", "compute_package_fq_deps", "new_feature_resolutions", "resolve_package_facts", "select_package_fq_dep", "split_lockfile_packages")
+load(":resolver.bzl", "resolve")
 
 def _select_package_fq_dep_uses_package_name_impl(ctx):
     env = unittest.begin(ctx)
@@ -265,12 +266,130 @@ def _resolve_package_facts_attaches_feature_resolutions_impl(ctx):
 
 resolve_package_facts_attaches_feature_resolutions_test = unittest.make(_resolve_package_facts_attaches_feature_resolutions_impl)
 
+def _resolve_package_facts_preserves_persisted_dependency_features_impl(ctx):
+    env = unittest.begin(ctx)
+
+    facts = {
+        "consumer-1.0.0": {
+            "dependencies": [
+                {
+                    "default_features": True,
+                    "features": ["derive"],
+                    "name": "helper",
+                },
+            ],
+            "features": {},
+        },
+        "helper-1.0.0": {
+            "dependencies": [],
+            "features": {},
+        },
+    }
+    packages = [
+        {
+            "dependencies": ["helper 1.0.0"],
+            "name": "consumer",
+            "version": "1.0.0",
+        },
+        {
+            "dependencies": [],
+            "name": "helper",
+            "version": "1.0.0",
+        },
+    ]
+
+    first = resolve_package_facts(packages, facts, ["x86_64-unknown-linux-gnu"])
+    resolve_package_facts([dict(package) for package in packages], facts, ["x86_64-unknown-linux-gnu"])
+
+    asserts.equals(env, ["derive"], facts["consumer-1.0.0"]["dependencies"][0]["features"])
+    asserts.equals(
+        env,
+        ["derive", "default"],
+        first.feature_resolutions_by_fq_crate["consumer-1.0.0"].possible_deps[0]["features"],
+    )
+    return unittest.end(env)
+
+resolve_package_facts_preserves_persisted_dependency_features_test = unittest.make(_resolve_package_facts_preserves_persisted_dependency_features_impl)
+
+def _resolve_handles_dependency_chains_deeper_than_round_limit_impl(ctx):
+    env = unittest.begin(ctx)
+
+    triple = "x86_64-unknown-linux-gnu"
+    triples = [triple]
+    packages = []
+    resolutions = []
+    resolutions_by_crate = {}
+    for index in range(60):
+        name = "chain-%s" % index
+        possible_deps = []
+        if index:
+            possible_deps.append({
+                "bazel_target": "//:chain-%s" % (index - 1),
+                "feature_resolutions": resolutions[index - 1],
+                "name": "chain-%s" % (index - 1),
+                "target": set(triples),
+            })
+
+        possible_features = {"forward": []}
+        if index:
+            possible_features["forward"] = ["chain-%s/forward" % (index - 1)]
+
+        resolution = new_feature_resolutions(index, possible_deps, possible_features, triples)
+        resolutions.append(resolution)
+        resolutions_by_crate["%s-1.0.0" % name] = resolution
+        packages.append({
+            "feature_resolutions": resolution,
+            "name": name,
+            "version": "1.0.0",
+        })
+
+    resolutions[-1].features_enabled[triple].add("forward")
+    resolve(None, packages, resolutions_by_crate, {}, False)
+
+    asserts.true(env, "forward" in resolutions[0].features_enabled[triple])
+    asserts.equals(env, ["//:chain-0"], sorted(resolutions[1].deps[triple]))
+    return unittest.end(env)
+
+resolve_handles_dependency_chains_deeper_than_round_limit_test = unittest.make(_resolve_handles_dependency_chains_deeper_than_round_limit_impl)
+
+def _resolve_handles_feature_chains_deeper_than_round_limit_impl(ctx):
+    env = unittest.begin(ctx)
+
+    triple = "x86_64-unknown-linux-gnu"
+    triples = [triple]
+    possible_features = {}
+    for index in range(60):
+        feature = "feature-%s" % index
+        possible_features[feature] = [] if index == 59 else ["feature-%s" % (index + 1)]
+
+    resolution = new_feature_resolutions(0, [], possible_features, triples)
+    resolution.features_enabled[triple].add("feature-0")
+    resolve(
+        None,
+        [{
+            "feature_resolutions": resolution,
+            "name": "feature-chain",
+            "version": "1.0.0",
+        }],
+        {"feature-chain-1.0.0": resolution},
+        {},
+        False,
+    )
+
+    asserts.true(env, "feature-59" in resolution.features_enabled[triple])
+    return unittest.end(env)
+
+resolve_handles_feature_chains_deeper_than_round_limit_test = unittest.make(_resolve_handles_feature_chains_deeper_than_round_limit_impl)
+
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
         cargo_toml_dependencies_handles_workspace_inheritance_test,
         cargo_toml_dependencies_normalizes_dependency_specs_test,
+        resolve_handles_dependency_chains_deeper_than_round_limit_test,
+        resolve_handles_feature_chains_deeper_than_round_limit_test,
         resolve_package_facts_attaches_feature_resolutions_test,
+        resolve_package_facts_preserves_persisted_dependency_features_test,
         select_package_fq_dep_uses_package_name_test,
         select_package_fq_dep_uses_req_for_duplicate_versions_test,
         split_lockfile_packages_finds_local_package_paths_test,

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -311,7 +311,7 @@ def _resolve_package_facts_preserves_persisted_dependency_features_impl(ctx):
 
 resolve_package_facts_preserves_persisted_dependency_features_test = unittest.make(_resolve_package_facts_preserves_persisted_dependency_features_impl)
 
-def _resolve_handles_dependency_chains_deeper_than_round_limit_impl(ctx):
+def _resolve_handles_dependency_chains_deeper_than_previous_round_limit_impl(ctx):
     env = unittest.begin(ctx)
 
     triple = "x86_64-unknown-linux-gnu"
@@ -350,9 +350,9 @@ def _resolve_handles_dependency_chains_deeper_than_round_limit_impl(ctx):
     asserts.equals(env, ["//:chain-0"], sorted(resolutions[1].deps[triple]))
     return unittest.end(env)
 
-resolve_handles_dependency_chains_deeper_than_round_limit_test = unittest.make(_resolve_handles_dependency_chains_deeper_than_round_limit_impl)
+resolve_handles_dependency_chains_deeper_than_previous_round_limit_test = unittest.make(_resolve_handles_dependency_chains_deeper_than_previous_round_limit_impl)
 
-def _resolve_handles_feature_chains_deeper_than_round_limit_impl(ctx):
+def _resolve_handles_feature_chains_deeper_than_previous_round_limit_impl(ctx):
     env = unittest.begin(ctx)
 
     triple = "x86_64-unknown-linux-gnu"
@@ -379,15 +379,15 @@ def _resolve_handles_feature_chains_deeper_than_round_limit_impl(ctx):
     asserts.true(env, "feature-59" in resolution.features_enabled[triple])
     return unittest.end(env)
 
-resolve_handles_feature_chains_deeper_than_round_limit_test = unittest.make(_resolve_handles_feature_chains_deeper_than_round_limit_impl)
+resolve_handles_feature_chains_deeper_than_previous_round_limit_test = unittest.make(_resolve_handles_feature_chains_deeper_than_previous_round_limit_impl)
 
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
         cargo_toml_dependencies_handles_workspace_inheritance_test,
         cargo_toml_dependencies_normalizes_dependency_specs_test,
-        resolve_handles_dependency_chains_deeper_than_round_limit_test,
-        resolve_handles_feature_chains_deeper_than_round_limit_test,
+        resolve_handles_dependency_chains_deeper_than_previous_round_limit_test,
+        resolve_handles_feature_chains_deeper_than_previous_round_limit_test,
         resolve_package_facts_attaches_feature_resolutions_test,
         resolve_package_facts_preserves_persisted_dependency_features_test,
         select_package_fq_dep_uses_package_name_test,

--- a/rs/private/cargo_workspace_graph_test.bzl
+++ b/rs/private/cargo_workspace_graph_test.bzl
@@ -352,42 +352,12 @@ def _resolve_handles_dependency_chains_deeper_than_previous_round_limit_impl(ctx
 
 resolve_handles_dependency_chains_deeper_than_previous_round_limit_test = unittest.make(_resolve_handles_dependency_chains_deeper_than_previous_round_limit_impl)
 
-def _resolve_handles_feature_chains_deeper_than_previous_round_limit_impl(ctx):
-    env = unittest.begin(ctx)
-
-    triple = "x86_64-unknown-linux-gnu"
-    triples = [triple]
-    possible_features = {}
-    for index in range(60):
-        feature = "feature-%s" % index
-        possible_features[feature] = [] if index == 59 else ["feature-%s" % (index + 1)]
-
-    resolution = new_feature_resolutions(0, [], possible_features, triples)
-    resolution.features_enabled[triple].add("feature-0")
-    resolve(
-        None,
-        [{
-            "feature_resolutions": resolution,
-            "name": "feature-chain",
-            "version": "1.0.0",
-        }],
-        {"feature-chain-1.0.0": resolution},
-        {},
-        False,
-    )
-
-    asserts.true(env, "feature-59" in resolution.features_enabled[triple])
-    return unittest.end(env)
-
-resolve_handles_feature_chains_deeper_than_previous_round_limit_test = unittest.make(_resolve_handles_feature_chains_deeper_than_previous_round_limit_impl)
-
 def cargo_workspace_graph_tests():
     return unittest.suite(
         "cargo_workspace_graph_tests",
         cargo_toml_dependencies_handles_workspace_inheritance_test,
         cargo_toml_dependencies_normalizes_dependency_specs_test,
         resolve_handles_dependency_chains_deeper_than_previous_round_limit_test,
-        resolve_handles_feature_chains_deeper_than_previous_round_limit_test,
         resolve_package_facts_attaches_feature_resolutions_test,
         resolve_package_facts_preserves_persisted_dependency_features_test,
         select_package_fq_dep_uses_package_name_test,

--- a/rs/private/resolver.bzl
+++ b/rs/private/resolver.bzl
@@ -175,13 +175,24 @@ def _propagate_feature_enablement(
 
     return package_changed
 
-_MAX_ROUNDS = 50
+_MAX_ROUNDS = 200
 
 def resolve(mctx, packages, feature_resolutions_by_fq_crate, cfg_attrs_by_triple, debug):
     # Do some rounds of mutual resolution; bail when no more changes
     dirty_package_indices = range(len(packages))
-    for i in range(_MAX_ROUNDS):
-        mctx.report_progress("Running round %s of dependency/feature resolution" % i)
+
+    # With adverse package ordering, feature enablement can advance by only one
+    # crate or feature alias per round. Allow for every possible feature state
+    # in addition to a full graph traversal and the convergence allowance.
+    max_rounds = len(packages) + _MAX_ROUNDS
+    for feature_resolutions in feature_resolutions_by_fq_crate.values():
+        max_rounds += (
+            len(feature_resolutions.possible_features) *
+            len(feature_resolutions.features_enabled)
+        )
+    for i in range(max_rounds):
+        if mctx:
+            mctx.report_progress("Running round %s of dependency/feature resolution" % i)
 
         dirty_package_indices = _resolve_one_round(packages, dirty_package_indices, cfg_attrs_by_triple, debug)
         if not dirty_package_indices:
@@ -191,5 +202,5 @@ def resolve(mctx, packages, feature_resolutions_by_fq_crate, cfg_attrs_by_triple
             break
         dirty_package_indices = sorted(dirty_package_indices)
 
-        if i == _MAX_ROUNDS:
-            fail("Resolution did not converge! This is likely a bug in rules_rs, please report it to github.com/hermeticbuild/rules_rs")
+    if dirty_package_indices:
+        fail("Resolution did not converge after %s rounds! This is likely a bug in rules_rs, please report it to github.com/hermeticbuild/rules_rs" % max_rounds)

--- a/rs/private/resolver.bzl
+++ b/rs/private/resolver.bzl
@@ -181,16 +181,7 @@ def resolve(mctx, packages, feature_resolutions_by_fq_crate, cfg_attrs_by_triple
     # Do some rounds of mutual resolution; bail when no more changes
     dirty_package_indices = range(len(packages))
 
-    # With adverse package ordering, feature enablement can advance by only one
-    # crate or feature alias per round. Allow for every possible feature state
-    # in addition to a full graph traversal and the convergence allowance.
-    max_rounds = len(packages) + _MAX_ROUNDS
-    for feature_resolutions in feature_resolutions_by_fq_crate.values():
-        max_rounds += (
-            len(feature_resolutions.possible_features) *
-            len(feature_resolutions.features_enabled)
-        )
-    for i in range(max_rounds):
+    for i in range(_MAX_ROUNDS):
         if mctx:
             mctx.report_progress("Running round %s of dependency/feature resolution" % i)
 
@@ -203,4 +194,4 @@ def resolve(mctx, packages, feature_resolutions_by_fq_crate, cfg_attrs_by_triple
         dirty_package_indices = sorted(dirty_package_indices)
 
     if dirty_package_indices:
-        fail("Resolution did not converge after %s rounds! This is likely a bug in rules_rs, please report it to github.com/hermeticbuild/rules_rs" % max_rounds)
+        fail("Resolution did not converge after %s rounds! This is likely a bug in rules_rs, please report it to github.com/hermeticbuild/rules_rs" % _MAX_ROUNDS)


### PR DESCRIPTION
Deep dependency and feature chains can exceed the resolver's previous 50-round threshold, while the convergence failure check could never execute. Resolution could also mutate feature lists originating from persisted dependency facts when injecting the implicit `default` feature.

## Changes

- raise the resolver round allowance beyond the previous 50-round threshold
- check for non-convergence after the resolution loop so the failure path is reachable
- copy dependency feature lists before injecting the implicit `default` feature