### PR TITLE
feat: re-export rust_test_suite

### DIFF
--- a/rs/rust_test.bzl
+++ b/rs/rust_test.bzl
@@ -1,3 +1,8 @@
-load("@rules_rust//rust:defs.bzl", _rust_test = "rust_test")
+load(
+    "@rules_rust//rust:defs.bzl",
+    _rust_test = "rust_test",
+    _rust_test_suite = "rust_test_suite",
+)
 
 rust_test = _rust_test
+rust_test_suite = _rust_test_suite

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -3,7 +3,7 @@ load("@build_script_aliases//:data.bzl", build_script_aliases_dep_data = "DEP_DA
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
-load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rs//rs:rust_test.bzl", "rust_test", "rust_test_suite")
 load("@rules_rust//rust:defs.bzl", "rust_doc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@self_dev_dependency//:data.bzl", self_dev_dependency_dep_data = "DEP_DATA")
@@ -121,6 +121,15 @@ rust_test(
         "@many_workspace_deps//:aws-lc-rs-1.17.1",
         "@many_workspace_deps//:aws-lc-sys-0.42.0",
     ],
+)
+
+rust_test_suite(
+    name = "rust_test_suite_smoke",
+    srcs = [
+        "rust_test_suite_a.rs",
+        "rust_test_suite_b.rs",
+    ],
+    shared_srcs = ["rust_test_suite_shared.rs"],
 )
 
 rust_binary(

--- a/test/rust_test_suite_a.rs
+++ b/test/rust_test_suite_a.rs
@@ -1,0 +1,6 @@
+mod rust_test_suite_shared;
+
+#[test]
+fn shared_source_is_available_to_first_test() {
+    assert_eq!(rust_test_suite_shared::answer(), 42);
+}

--- a/test/rust_test_suite_b.rs
+++ b/test/rust_test_suite_b.rs
@@ -1,0 +1,6 @@
+mod rust_test_suite_shared;
+
+#[test]
+fn shared_source_is_available_to_second_test() {
+    assert_eq!(rust_test_suite_shared::answer(), 42);
+}

--- a/test/rust_test_suite_shared.rs
+++ b/test/rust_test_suite_shared.rs
@@ -1,0 +1,3 @@
+pub fn answer() -> u32 {
+    42
+}


### PR DESCRIPTION
## Summary

- re-export upstream `rust_test_suite` from the `rules_rs` Rust test façade
- add an integration smoke test with two test roots and a shared source

## Why

`rules_rust` already provides `rust_test_suite` for Cargo-style integration
tests, but `rules_rs` only exposed `rust_test`. Consumers therefore had to
either load from the generated `@rules_rust` repository directly or maintain
their own equivalent macro.

Exposing the suite alongside `rust_test` keeps consumers on the `@rules_rs`
public API.

## Validation

- `bazelisk build //rs:rust_test`
- `cd test && bazelisk test //:rust_test_suite_smoke`
- buildifier check on the changed Starlark files
- `rustfmt --check` on the new Rust test sources
- `git diff --check`
