### PR TITLE
Add global Cargo configuration for crate closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ use_repo(crate, "crates")
 
 `platform_triples` should include every exec and target triple that can participate in the build. For the common case, include the host triples you use locally and in CI plus the target triples you build for.
 
+### Global Cargo configuration
+
+The root module can configure a shared Cargo configuration file for every Cargo closure, including closures declared by dependencies:
+
+```bzl
+crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")
+crate.config(
+    cargo_config_toml = "//:.cargo/config.toml",
+    use_home_cargo_credentials = True,  # Optional.
+)
+```
+
+Use `cargo_config_toml` to configure custom Cargo registries such as Artifactory, including `[source.crates-io]` replacements. Set `use_home_cargo_credentials = True` when the registry requires credentials from `~/.cargo/credentials.toml`.
+
+A closure that supplies `crate.from_cargo(cargo_config = ...)` uses its own configuration file instead. Only the root module's `crate.config` applies globally; `crate.config` tags in dependency modules are ignored.
+
 ### `.bazelrc`
 
 Linux hosts work with Bazel's default host platform. If you also build on Windows,

--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -642,7 +642,8 @@ def _crate_impl(mctx):
     downloader_state = new_downloader_state()
     suggested_annotation_snippet_paths = well_known_annotation_snippet_paths(mctx)
 
-    global_config = None
+    global_cargo_config = None
+    global_use_home_cargo_credentials = False
     for mod in mctx.modules:
         if not mod.is_root:
             continue
@@ -651,7 +652,8 @@ def _crate_impl(mctx):
             fail("Only one `crate.config` tag may be declared by the root module")
 
         if mod.tags.config:
-            global_config = mod.tags.config[0]
+            global_cargo_config = mod.tags.config[0].cargo_config_toml
+            global_use_home_cargo_credentials = mod.tags.config[0].use_home_cargo_credentials
 
     packages_by_hub_name = {}
     cargo_toml_by_hub_name = {}
@@ -673,9 +675,9 @@ def _crate_impl(mctx):
             mctx.watch(cfg.cargo_lock)
             mctx.watch(cfg.cargo_toml)
 
-            effective_cargo_config = cfg.cargo_config or (global_config.cargo_config_toml if global_config else None)
+            effective_cargo_config = cfg.cargo_config or global_cargo_config
             cargo_config_by_hub_name[cfg.name] = effective_cargo_config
-            use_home_cargo_credentials_by_hub_name[cfg.name] = cfg.use_home_cargo_credentials or (global_config.use_home_cargo_credentials if global_config else False)
+            use_home_cargo_credentials_by_hub_name[cfg.name] = cfg.use_home_cargo_credentials or global_use_home_cargo_credentials
 
             cargo_config = {}
             if effective_cargo_config:

--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -642,13 +642,29 @@ def _crate_impl(mctx):
     downloader_state = new_downloader_state()
     suggested_annotation_snippet_paths = well_known_annotation_snippet_paths(mctx)
 
+    global_config = None
+    for mod in mctx.modules:
+        if not mod.is_root:
+            continue
+
+        if len(mod.tags.config) > 1:
+            fail("Only one `crate.config` tag may be declared by the root module")
+
+        if mod.tags.config:
+            global_config = mod.tags.config[0]
+
     packages_by_hub_name = {}
     cargo_toml_by_hub_name = {}
+    cargo_config_by_hub_name = {}
+    parsed_cargo_configs = {}
     cargo_credentials_by_hub_name = {}
+    use_home_cargo_credentials_by_hub_name = {}
     annotations_by_hub_name = {}
 
     for mod in mctx.modules:
         if not mod.tags.from_cargo:
+            if mod.tags.config:
+                continue
             fail("`.from_cargo` is required. Please update %s" % mod.name)
 
         for cfg in mod.tags.from_cargo:
@@ -656,10 +672,20 @@ def _crate_impl(mctx):
             annotations_by_hub_name[cfg.name] = annotations
             mctx.watch(cfg.cargo_lock)
             mctx.watch(cfg.cargo_toml)
+
+            effective_cargo_config = cfg.cargo_config or (global_config.cargo_config_toml if global_config else None)
+            cargo_config_by_hub_name[cfg.name] = effective_cargo_config
+            use_home_cargo_credentials_by_hub_name[cfg.name] = cfg.use_home_cargo_credentials or (global_config.use_home_cargo_credentials if global_config else False)
+
             cargo_config = {}
-            if cfg.cargo_config:
-                mctx.watch(cfg.cargo_config)
-                cargo_config = run_toml2json(mctx, cfg.cargo_config)
+            if effective_cargo_config:
+                cargo_config_key = str(effective_cargo_config)
+                cargo_config = parsed_cargo_configs.get(cargo_config_key)
+                if cargo_config == None:
+                    mctx.watch(effective_cargo_config)
+                    cargo_config = run_toml2json(mctx, effective_cargo_config)
+                    parsed_cargo_configs[cargo_config_key] = cargo_config
+
             cargo_toml_by_hub_name[cfg.name] = run_toml2json(mctx, cfg.cargo_toml)
             cargo_lock = run_toml2json(mctx, cfg.cargo_lock)
             parsed_packages = cargo_lock.get("package", [])
@@ -677,12 +703,14 @@ def _crate_impl(mctx):
     for mod in mctx.modules:
         for cfg in mod.tags.from_cargo:
             annotations = build_annotation_map(mod, cfg.name)
+            effective_cargo_config = cargo_config_by_hub_name[cfg.name]
+            use_home_cargo_credentials = use_home_cargo_credentials_by_hub_name[cfg.name]
 
-            if cfg.use_home_cargo_credentials:
-                if not cfg.cargo_config:
-                    fail("Must provide cargo_config when using cargo credentials")
+            if use_home_cargo_credentials:
+                if not effective_cargo_config:
+                    fail("Must provide cargo_config or crate.config(cargo_config_toml = ...) when using cargo credentials")
 
-                cargo_credentials = load_cargo_credentials(mctx, cfg.cargo_config)
+                cargo_credentials = load_cargo_credentials(mctx, effective_cargo_config)
             else:
                 cargo_credentials = {}
 
@@ -700,8 +728,8 @@ def _crate_impl(mctx):
                 registry_config_repository(
                     name = registry_config_repo_name(cfg.name, source),
                     source = source,
-                    cargo_config = cfg.cargo_config,
-                    use_home_cargo_credentials = cfg.use_home_cargo_credentials,
+                    cargo_config = effective_cargo_config,
+                    use_home_cargo_credentials = use_home_cargo_credentials,
                 )
 
     for fetch_state in downloader_state.in_flight_git_crate_fetches_by_url.values():
@@ -722,15 +750,16 @@ def _crate_impl(mctx):
                     direct_deps.append(cfg.name)
 
             hub_packages = packages_by_hub_name[cfg.name]
+            effective_cargo_config = cargo_config_by_hub_name[cfg.name]
             cargo_credentials = cargo_credentials_by_hub_name[cfg.name]
 
             annotations = build_annotation_map(mod, cfg.name)
 
             if cfg.debug:
                 for _ in range(25):
-                    _generate_hub_and_spokes(mctx, cfg.name, annotations, suggested_annotation_snippet_paths, cargo_path, cfg.cargo_lock, cargo_toml_by_hub_name[cfg.name], hub_packages, cfg.platform_triples, cargo_credentials, cfg.cargo_config, cfg.validate_lockfile, cfg.debug, cfg.use_legacy_rules_rust_platforms, dry_run = True)
+                    _generate_hub_and_spokes(mctx, cfg.name, annotations, suggested_annotation_snippet_paths, cargo_path, cfg.cargo_lock, cargo_toml_by_hub_name[cfg.name], hub_packages, cfg.platform_triples, cargo_credentials, effective_cargo_config, cfg.validate_lockfile, cfg.debug, cfg.use_legacy_rules_rust_platforms, dry_run = True)
 
-            facts |= _generate_hub_and_spokes(mctx, cfg.name, annotations, suggested_annotation_snippet_paths, cargo_path, cfg.cargo_lock, cargo_toml_by_hub_name[cfg.name], hub_packages, cfg.platform_triples, cargo_credentials, cfg.cargo_config, cfg.validate_lockfile, cfg.debug, cfg.use_legacy_rules_rust_platforms)
+            facts |= _generate_hub_and_spokes(mctx, cfg.name, annotations, suggested_annotation_snippet_paths, cargo_path, cfg.cargo_lock, cargo_toml_by_hub_name[cfg.name], hub_packages, cfg.platform_triples, cargo_credentials, effective_cargo_config, cfg.validate_lockfile, cfg.debug, cfg.use_legacy_rules_rust_platforms)
 
     # Lay down the git repos with generated per-crate BUILD overlays.
     git_repos = {}
@@ -816,6 +845,19 @@ def _crate_impl(mctx):
         kwargs["facts"] = facts
 
     return mctx.extension_metadata(**kwargs)
+
+_config = tag_class(
+    doc = "Global Cargo configuration for closures that do not provide their own cargo_config.",
+    attrs = {
+        "cargo_config_toml": attr.label(
+            doc = "The Cargo configuration file applied to every closure without cargo_config.",
+            mandatory = True,
+        ),
+        "use_home_cargo_credentials": attr.bool(
+            doc = "Load ~/.cargo/credentials.toml for every Cargo closure.",
+        ),
+    },
+)
 
 _from_cargo = tag_class(
     doc = "Generates a repo @crates from a Cargo.toml / Cargo.lock pair.",
@@ -1010,6 +1052,7 @@ crate = module_extension(
     implementation = _crate_impl,
     tag_classes = {
         "annotation": _annotation,
+        "config": _config,
         "from_cargo": _from_cargo,
     },
 )

--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -645,6 +645,7 @@ def _crate_impl(mctx):
     global_cargo_config = None
     global_use_home_cargo_credentials = False
     for mod in mctx.modules:
+        # A dependency's standalone configuration must not override the root module's configuration.
         if not mod.is_root:
             continue
 
@@ -660,12 +661,13 @@ def _crate_impl(mctx):
     cargo_config_by_hub_name = {}
     parsed_cargo_configs = {}
     cargo_credentials_by_hub_name = {}
-    use_home_cargo_credentials_by_hub_name = {}
     annotations_by_hub_name = {}
 
     for mod in mctx.modules:
         if not mod.tags.from_cargo:
             if mod.tags.config:
+                # The root module can configure dependency closures without declaring a closure.
+                # Dependency modules that only declare crate.config remain valid when ignored.
                 continue
             fail("`.from_cargo` is required. Please update %s" % mod.name)
 
@@ -677,7 +679,6 @@ def _crate_impl(mctx):
 
             effective_cargo_config = cfg.cargo_config or global_cargo_config
             cargo_config_by_hub_name[cfg.name] = effective_cargo_config
-            use_home_cargo_credentials_by_hub_name[cfg.name] = cfg.use_home_cargo_credentials or global_use_home_cargo_credentials
 
             cargo_config = {}
             if effective_cargo_config:
@@ -706,7 +707,7 @@ def _crate_impl(mctx):
         for cfg in mod.tags.from_cargo:
             annotations = build_annotation_map(mod, cfg.name)
             effective_cargo_config = cargo_config_by_hub_name[cfg.name]
-            use_home_cargo_credentials = use_home_cargo_credentials_by_hub_name[cfg.name]
+            use_home_cargo_credentials = cfg.use_home_cargo_credentials or global_use_home_cargo_credentials
 
             if use_home_cargo_credentials:
                 if not effective_cargo_config:


### PR DESCRIPTION
## Summary

- Add root-owned `crate.config(cargo_config_toml = ..., use_home_cargo_credentials = ...)` configuration for every Cargo closure, including dependency-owned closures.
- Preserve `crate.from_cargo(cargo_config = ...)` precedence, ignore dependency-owned `crate.config` tags, and reuse parsed configuration across closures.
- Document custom Cargo registries such as Artifactory, `crates.io` source replacement, and Cargo credentials.

## Validation

- `python3 -u -B test/custom_registry_test.py`
- `bazel --ignore_all_rc_files --batch --output_base=<temporary> test --jobs=1 --test_output=errors //rs/private:all` (38 tests passed)
- Temporary sparse-registry workspace covering dependency-owned closures, configuration-only roots, ignored dependency configuration, and closure-specific overrides.
- `buildifier -mode=check rs/extensions.bzl`
- `git diff --check`
