### PR TITLE
Load dedicated rules_rust toolchain and provider files

### DIFF
--- a/3rd_party/aws-lc-sys/BUILD.bazel
+++ b/3rd_party/aws-lc-sys/BUILD.bazel
@@ -13,6 +13,6 @@ bzl_library(
         "@bazel_lib//lib:copy_to_directory",
         "@rules_cc//cc:defs_bzl",
         "@rules_rs//rs:rules_rust_bindgen",
-        "@rules_rust//rust:bzl_lib",
+        "@rules_rust//rust/private:bzl_lib",
     ],
 )

--- a/3rd_party/aws-lc-sys/defs.bzl
+++ b/3rd_party/aws-lc-sys/defs.bzl
@@ -3,7 +3,7 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_library")
 load("@rules_rs//rs:rules_rust_bindgen.bzl", "rust_bindgen")
-load("@rules_rust//rust:rust_common.bzl", "BuildInfo")
+load("@rules_rust//rust/private:providers.bzl", "BuildInfo")
 
 def _aws_lc_sys_build_info_impl(ctx):
     out_dir = ctx.file.out_dir

--- a/3rd_party/coreaudio-sys/BUILD.bazel
+++ b/3rd_party/coreaudio-sys/BUILD.bazel
@@ -14,6 +14,6 @@ bzl_library(
         "@bazel_lib//lib:copy_to_directory",
         "@rules_cc//cc:defs_bzl",
         "@rules_rs//rs:rules_rust_bindgen",
-        "@rules_rust//rust:bzl_lib",
+        "@rules_rust//rust/private:bzl_lib",
     ],
 )

--- a/3rd_party/coreaudio-sys/defs.bzl
+++ b/3rd_party/coreaudio-sys/defs.bzl
@@ -3,7 +3,7 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_library")
 load("@rules_rs//rs:rules_rust_bindgen.bzl", "rust_bindgen")
-load("@rules_rust//rust:rust_common.bzl", "BuildInfo")
+load("@rules_rust//rust/private:providers.bzl", "BuildInfo")
 
 def _coreaudio_sys_build_info_impl(ctx):
     out_dir = ctx.file.out_dir

--- a/rs/experimental/miri/private/BUILD.bazel
+++ b/rs/experimental/miri/private/BUILD.bazel
@@ -29,7 +29,6 @@ bzl_library(
         ":toolchain",
         "@bazel_skylib//lib:structs",
         "@rules_cc//cc/common",
-        "@rules_rust//rust:bzl_lib",
         "@rules_rust//rust/platform:bzl_lib",
         "@rules_rust//rust/private:bzl_lib",
     ],

--- a/rs/experimental/miri/private/compile.bzl
+++ b/rs/experimental/miri/private/compile.bzl
@@ -2,8 +2,9 @@
 
 load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load(
-    "@rules_rust//rust:rust_common.bzl",
+    "@rules_rust//rust/private:providers.bzl",
     "BuildInfo",
     "CrateGroupInfo",
     "CrateInfo",
@@ -11,7 +12,6 @@ load(
     "DepVariantInfo",
     "TestCrateInfo",
 )
-load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load("@rules_rust//rust/private:rustc.bzl", "rustc_compile")
 load("@rules_rust//rust/private:utils.bzl", "determine_output_hash")
 load("//rs/experimental/miri/private:providers.bzl", "MiriCrateInfo")

--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
-load("@rules_rust//rust:defs.bzl", "rust_stdlib_filegroup")
+load("@rules_rust//rust:rust_stdlib_filegroup.bzl", "rust_stdlib_filegroup")
 load(":all_crate_deps_test.bzl", "all_crate_deps_tests")
 load(":bindgen_test.bzl", "bindgen_tests")
 load(":bpf_linker_repository_test.bzl", "bpf_linker_repository_tests")
@@ -202,7 +202,10 @@ bzl_library(
     name = "source_stdlib",
     srcs = ["source_stdlib.bzl"],
     visibility = ["//rs:__subpackages__"],
-    deps = ["@rules_rust//rust:bzl_lib"],
+    deps = [
+        "@rules_rust//rust:bzl_lib",
+        "@rules_rust//rust/private:bzl_lib",
+    ],
 )
 
 bzl_library(

--- a/rs/private/source_stdlib.bzl
+++ b/rs/private/source_stdlib.bzl
@@ -1,5 +1,5 @@
-load("@rules_rust//rust:defs.bzl", "rust_stdlib_filegroup")
-load("@rules_rust//rust:rust_common.bzl", "CrateInfo", "DepInfo")
+load("@rules_rust//rust:rust_stdlib_filegroup.bzl", "rust_stdlib_filegroup")
+load("@rules_rust//rust/private:providers.bzl", "CrateInfo", "DepInfo")
 
 def _source_stdlib_build_transition_impl(_settings, _attr):
     return {

--- a/rs/private/stdlib_repository.bzl
+++ b/rs/private/stdlib_repository.bzl
@@ -3,7 +3,7 @@ load("@rules_rust//rust/platform:triple_mappings.bzl", "system_to_dylib_ext", "s
 load(":rust_repository_utils.bzl", "RUST_REPOSITORY_COMMON_ATTR", "download_and_extract")
 
 _build_file_tmpl = """\
-load("@rules_rust//rust:toolchain.bzl", "rust_stdlib_filegroup")
+load("@rules_rust//rust:rust_stdlib_filegroup.bzl", "rust_stdlib_filegroup")
 
 rust_stdlib_filegroup(
     name = "rust_std-{target_triple}",

--- a/rs/toolchains/declare_rust_analyzer_toolchains.bzl
+++ b/rs/toolchains/declare_rust_analyzer_toolchains.bzl
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:toolchain.bzl", "rust_analyzer_toolchain")
+load("@rules_rust//rust:rust_analyzer_toolchain.bzl", "rust_analyzer_toolchain")
 load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load("//rs/platforms:triples.bzl", "SUPPORTED_EXEC_TRIPLES")
 load("//rs/private:rust_repository_utils.bzl", "includes_rust_analyzer_proc_macro_srv")

--- a/rs/toolchains/declare_rustc_toolchains.bzl
+++ b/rs/toolchains/declare_rustc_toolchains.bzl
@@ -1,6 +1,6 @@
 """Definitions for declaring Rust compiler toolchains."""
 
-load("@rules_rust//rust:toolchain.bzl", "rust_toolchain")
+load("@rules_rust//rust:rust_toolchain.bzl", "rust_toolchain")
 load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load("//rs/platforms:triples.bzl", "ALL_TARGET_TRIPLES", "SUPPORTED_EXEC_TRIPLES", "SUPPORTED_TIER_3_TRIPLES", "triple_to_rust_constraint_set")
 load("//rs/private:bpf_linker_repository.bzl", "bpf_linker_binary_name", "bpf_linker_repository_name")

--- a/rs/toolchains/declare_rustfmt_toolchains.bzl
+++ b/rs/toolchains/declare_rustfmt_toolchains.bzl
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:toolchain.bzl", "rustfmt_toolchain")
+load("@rules_rust//rust:rustfmt_toolchain.bzl", "rustfmt_toolchain")
 load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
 load("//rs/platforms:triples.bzl", "SUPPORTED_EXEC_TRIPLES")
 load("//rs/toolchains:toolchain_utils.bzl", "sanitize_version")


### PR DESCRIPTION
## Summary

- Load dedicated `rust_toolchain.bzl`, `rustfmt_toolchain.bzl`, `rust_analyzer_toolchain.bzl`, and `rust_stdlib_filegroup.bzl` instead of broad `rules_rust` re-export files.
- Load `BuildInfo`, `CrateInfo`, `DepInfo`, and Miri providers directly from `rust/private:providers.bzl`.
- Update generated stdlib BUILD files and `bzl_library` dependencies to match the narrower Starlark imports.

## Validation

- `bazel --ignore_all_rc_files --batch --output_base=<existing-cache> test --lockfile_mode=off --jobs=1 --test_output=errors //rs/private:all //rs/toolchains:all //rs/experimental/miri/private:compile //3rd_party/aws-lc-sys:defs //3rd_party/coreaudio-sys:defs`
- All 38 existing `//rs/private` tests passed; changed toolchain, Miri, AWS-LC, and CoreAudio targets analyzed successfully.
- `buildifier -mode=check` for all 12 changed Starlark and BUILD files.
- `git diff --check`.
