### PR TITLE
Package rust-analyzer runtime libraries

### DIFF
--- a/rs/private/rust_analyzer_repository.bzl
+++ b/rs/private/rust_analyzer_repository.bzl
@@ -1,23 +1,35 @@
 load("@rules_rust//rust/platform:triple.bzl", "triple")
 load("@rules_rust//rust/platform:triple_mappings.bzl", "system_to_binary_ext")
-load(":rust_repository_utils.bzl", "RUST_REPOSITORY_COMMON_ATTR", "download_and_extract")
+load(":rust_repository_utils.bzl", "RUST_REPOSITORY_COMMON_ATTR", "download_and_extract", "rustc_lib_build_file")
 
 _build_file_tmpl = """\
 filegroup(
     name = "rust_analyzer",
     srcs = ["bin/rust-analyzer{binary_ext}"],
+    data = [":rustc_lib"],
     visibility = ["//visibility:public"],
 )
+
+{rustc_lib}
 """
 
 def _rust_analyzer_repository_impl(rctx):
     exec_triple = triple(rctx.attr.triple)
     download_and_extract(rctx, "rust-analyzer", "rust-analyzer-preview", exec_triple)
-    rctx.file("BUILD.bazel", _build_file_tmpl.format(binary_ext = system_to_binary_ext(exec_triple.system)))
+    download_and_extract(rctx, "rustc", "rustc", exec_triple, sha256 = rctx.attr.rustc_sha256)
+    rctx.file(
+        "BUILD.bazel",
+        _build_file_tmpl.format(
+            binary_ext = system_to_binary_ext(exec_triple.system),
+            rustc_lib = rustc_lib_build_file(exec_triple),
+        ),
+    )
 
     return rctx.repo_metadata(reproducible = True)
 
 rust_analyzer_repository = repository_rule(
     implementation = _rust_analyzer_repository_impl,
-    attrs = RUST_REPOSITORY_COMMON_ATTR,
+    attrs = {
+        "rustc_sha256": attr.string(mandatory = True),
+    } | RUST_REPOSITORY_COMMON_ATTR,
 )

--- a/rs/toolchains/module_extension.bzl
+++ b/rs/toolchains/module_extension.bzl
@@ -390,6 +390,7 @@ def _toolchains_impl(mctx):
                 version = base_version,
                 iso_date = iso_date,
                 sha256 = _sha_for("rust-analyzer", base_version, iso_date, exec_triple),
+                rustc_sha256 = _sha_for("rustc", base_version, iso_date, exec_triple),
             )
 
     if len(host_cargo_repos) != len(rust_versions):


### PR DESCRIPTION
Package rust-analyzer with its matching rustc runtime libraries, mirroring the Clippy/rustfmt pattern so the generated launcher works on macOS.