### PR TITLE
Support dev-only bindgen extension usage

### DIFF
--- a/rs/rules_rust_bindgen.bzl
+++ b/rs/rules_rust_bindgen.bzl
@@ -198,9 +198,17 @@ def _rules_rust_bindgen_impl(mctx):
     for name in sorted(toolchain_repositories):
         _rules_rust_bindgen_repo(name = name)
 
+    direct_deps = []
+    direct_dev_deps = []
+    if any([module.is_root for module in mctx.modules]):
+        if mctx.root_module_has_non_dev_dependency:
+            direct_deps = sorted(toolchain_repositories)
+        else:
+            direct_dev_deps = sorted(toolchain_repositories)
+
     return mctx.extension_metadata(
-        root_module_direct_deps = sorted(toolchain_repositories),
-        root_module_direct_dev_deps = [],
+        root_module_direct_deps = direct_deps,
+        root_module_direct_dev_deps = direct_dev_deps,
         reproducible = True,
     )
 


### PR DESCRIPTION
## Summary

- classify generated bindgen repositories as direct development dependencies when the root module uses the extension only with `dev_dependency = True`
- preserve normal direct-dependency metadata for non-development root usages
- avoid recommending imports when the root module does not use the extension

## Root cause

The bindgen extension always returned its generated repositories in `root_module_direct_deps`. Bazel rejects that metadata when the root extension usage is development-only because those repositories must instead be listed in `root_module_direct_dev_deps`.

## Impact

Root modules can make the bindgen extension development-only, so dependent modules do not evaluate or fetch the bindgen toolchain repositories unnecessarily. Existing non-development usages keep their current behavior.

## Validation

- exercised a development-only usage from `linux.bzl` through a local module override
- exercised the existing non-development usage through the same integration build
- both modes built `//internal/cmd/kconfig/prebuilts:kconfig_prebuilts` successfully
- buildifier check on `rs/rules_rust_bindgen.bzl`
- `git diff --check`
