### PR TITLE
fix: normalize RISC-V target arch in Cargo cfgs

### DIFF
--- a/rs/private/cfg_parser.bzl
+++ b/rs/private/cfg_parser.bzl
@@ -150,6 +150,15 @@ def _normalize_os(os_raw):
         return "macos"
     return os_raw
 
+def _normalize_arch(arch_raw):
+    # RISC-V target triples encode the enabled ISA extensions in their first
+    # component, while Rust's cfg(target_arch) exposes only the register width.
+    if arch_raw.startswith("riscv32"):
+        return "riscv32"
+    if arch_raw.startswith("riscv64"):
+        return "riscv64"
+    return arch_raw
+
 def _family_for_os(os_name):
     if os_name == "windows":
         return "windows"
@@ -211,7 +220,7 @@ def _target_has_feature(ctx, feature):
 
 def triple_to_cfg_attrs(triple):
     parts = triple.split("-")
-    arch_part = _get(parts, 0, "")
+    arch_part = _normalize_arch(_get(parts, 0, ""))
     vendor_part = _get(parts, 1, "unknown")
     os_raw_part = _get(parts, 2, "none")
     env_part = "-".join(parts[3:])

--- a/rs/private/cfg_parser_test.bzl
+++ b/rs/private/cfg_parser_test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":cfg_parser.bzl", "cfg_matches", "cfg_matches_expr_for_triples", "triple_to_cfg_attrs", "cfg_matches_expr_for_cfg_attrs")
+load(":cfg_parser.bzl", "cfg_matches", "cfg_matches_expr_for_cfg_attrs", "cfg_matches_expr_for_triples", "triple_to_cfg_attrs")
 
 def _cfg(expr):
     return "cfg(%s)" % expr
@@ -14,6 +14,8 @@ def _cfg_parser_smoke_test_impl(ctx):
     win_gnu = "x86_64-pc-windows-gnu"
     win_gnullvm = "aarch64-pc-windows-gnullvm"
     wasm = "wasm32-unknown-unknown"
+    riscv32imac = "riscv32imac-unknown-none-elf"
+    riscv64gc = "riscv64gc-unknown-linux-musl"
 
     # MacOS facts facts
     asserts.true(env, cfg_matches(_cfg("unix"), mac))
@@ -47,6 +49,15 @@ def _cfg_parser_smoke_test_impl(ctx):
     asserts.true(env, cfg_matches(_cfg('target_family = "wasm"'), wasm))
     asserts.true(env, cfg_matches(_cfg('target_pointer_width = "32"'), wasm))
 
+    # RISC-V triples include ISA extensions in the architecture component, but
+    # Rust exposes the register width through cfg(target_arch).
+    asserts.true(env, cfg_matches(_cfg('target_arch = "riscv32"'), riscv32imac))
+    asserts.true(env, cfg_matches(_cfg('target_pointer_width = "32"'), riscv32imac))
+    asserts.false(env, cfg_matches(_cfg('target_arch = "riscv32imac"'), riscv32imac))
+    asserts.true(env, cfg_matches(_cfg('target_arch = "riscv64"'), riscv64gc))
+    asserts.true(env, cfg_matches(_cfg('target_pointer_width = "64"'), riscv64gc))
+    asserts.false(env, cfg_matches(_cfg('target_arch = "riscv64gc"'), riscv64gc))
+
     # Combinators
     asserts.false(env, cfg_matches(_cfg("any()"), mac))
     asserts.true(env, cfg_matches(_cfg("not(any())"), mac))
@@ -63,15 +74,16 @@ def _cfg_parser_smoke_test_impl(ctx):
     asserts.true(env, cfg_matches(_cfg('target_feature = "sse2"'), linux_gnu))
     asserts.false(env, cfg_matches(_cfg('target_feature = "sse2"'), mac))
 
-    triples = [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm, wasm]
+    triples = [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm, wasm, riscv32imac, riscv64gc]
 
     results = cfg_matches_expr_for_triples(_cfg('all(unix, any(target_env = "gnu", target_env = "musl"))'), triples)
-    asserts.equals(env, results.matches, [linux_gnu, linux_musl])
+    asserts.equals(env, results.matches, [linux_gnu, linux_musl, riscv64gc])
 
     results = cfg_matches_expr_for_triples(
         _cfg('any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")'),
-        triples)
-    asserts.equals(env, results.matches, triples[:-1])
+        triples,
+    )
+    asserts.equals(env, results.matches, [mac, linux_gnu, linux_musl, win, win_gnu, win_gnullvm])
 
     # Cargo dependencies can target a specific triple instead of a cfg expression.
     results = cfg_matches_expr_for_triples(win_gnullvm, triples)


### PR DESCRIPTION
## Summary

- normalize ISA-bearing RISC-V triple architecture components to Rust cfg `target_arch` values
- cover both RV32IMAC and RV64GC
- use explicit expected architecture matches in the cfg-parser test

RISC-V target triples include ISA extensions in their architecture component, such as `riscv32imac` and `riscv64gc`. Rust's `target_arch` cfg instead exposes the canonical values `riscv32` and `riscv64`.

Without this normalization, Cargo dependencies gated on the standard RISC-V `target_arch` values can be omitted even though the selected target is RISC-V.

## Validation

- `pre-commit run buildifier --files rs/private/cfg_parser.bzl rs/private/cfg_parser_test.bzl`
- `bazel test //rs/private:cfg_parser_tests`
- `bazel test //...`
- `cd test && bazel test //...`
