### PR TITLE
Support platform-selectable crate annotations

### DIFF
--- a/rs/extensions.bzl
+++ b/rs/extensions.bzl
@@ -28,9 +28,6 @@ load("//rs/private:registry_utils.bzl", "CRATES_IO_REGISTRY", "registry_config_r
 load("//rs/private:repository_utils.bzl", "render_select")
 load("//rs/private:toml2json.bzl", "run_toml2json")
 
-# Bazel 8 does not define attr.label_list_dict.
-_label_list_dict = getattr(attr, "label_list_dict", attr.string_list_dict)
-
 def _spoke_repo(hub_name, name, version):
     s = "%s__%s-%s" % (hub_name, name, version)
     if "+" in s:
@@ -688,7 +685,7 @@ def _crate_impl(mctx):
             fail("`.from_cargo` is required. Please update %s" % mod.name)
 
         for cfg in mod.tags.from_cargo:
-            annotations = build_annotation_map(mod, cfg.name)
+            annotations = build_annotation_map(mod, cfg.name, cfg.platform_triples)
             annotations_by_hub_name[cfg.name] = annotations
             mctx.watch(cfg.cargo_lock)
             mctx.watch(cfg.cargo_toml)
@@ -721,7 +718,7 @@ def _crate_impl(mctx):
 
     for mod in mctx.modules:
         for cfg in mod.tags.from_cargo:
-            annotations = build_annotation_map(mod, cfg.name)
+            annotations = annotations_by_hub_name[cfg.name]
             effective_cargo_config = cargo_config_by_hub_name[cfg.name]
             use_home_cargo_credentials = cfg.use_home_cargo_credentials or global_use_home_cargo_credentials
 
@@ -772,7 +769,7 @@ def _crate_impl(mctx):
             effective_cargo_config = cargo_config_by_hub_name[cfg.name]
             cargo_credentials = cargo_credentials_by_hub_name[cfg.name]
 
-            annotations = build_annotation_map(mod, cfg.name)
+            annotations = annotations_by_hub_name[cfg.name]
 
             if cfg.debug:
                 for _ in range(25):
@@ -784,7 +781,7 @@ def _crate_impl(mctx):
     git_repos = {}
     for mod in mctx.modules:
         for cfg in mod.tags.from_cargo:
-            annotations = build_annotation_map(mod, cfg.name)
+            annotations = annotations_by_hub_name[cfg.name]
             for package in packages_by_hub_name[cfg.name]:
                 source = package.get("source", "")
                 if not source.startswith("git+"):
@@ -911,22 +908,41 @@ _from_cargo = tag_class(
     },
 )
 
+_ANNOTATION_COMMON_ATTRS = {
+    "crate": attr.string(
+        doc = "The name of the crate the annotation is applied to",
+        mandatory = True,
+    ),
+    "version": attr.string(
+        doc = "The version of the crate the annotation is applied to. Defaults to all versions.",
+        default = "*",
+    ),
+    "repositories": attr.string_list(
+        doc = "Repository names specified by crate.from_cargo(name=...). Defaults to all repositories.",
+    ),
+}
+
+_ANNOTATION_SELECTABLE_ATTRS = {
+    "build_script_data": attr.label_list(
+        doc = "Labels to add to a crate's `cargo_build_script::data` attribute.",
+    ),
+    "build_script_env": attr.string_dict(
+        doc = "Environment variables to add to a crate's `cargo_build_script::env` attribute.",
+    ),
+    "build_script_tools": attr.label_list(
+        doc = "Labels to add to a crate's `cargo_build_script::tools` attribute.",
+    ),
+    "crate_features": attr.string_list(
+        doc = "Features to add to a crate's `rust_library::crate_features` attribute.",
+    ),
+    "rustc_flags": attr.string_list(
+        doc = "Flags to add to a crate's `rust_library::rustc_flags` attribute.",
+    ),
+}
+
 _annotation = tag_class(
     doc = "A collection of extra attributes and settings for a particular crate.",
-    attrs = {
-        "crate": attr.string(
-            doc = "The name of the crate the annotation is applied to",
-            mandatory = True,
-        ),
-        "version": attr.string(
-            doc = "The version of the crate the annotation is applied to. Defaults to all versions.",
-            default = "*",
-        ),
-        "repositories": attr.string_list(
-            doc = "A list of repository names specified from `crate.from_cargo(name=...)` that this annotation is applied to. Defaults to all repositories.",
-            default = [],
-        ),
-    } | {
+    attrs = _ANNOTATION_COMMON_ATTRS | _ANNOTATION_SELECTABLE_ATTRS | {
         "additive_build_file": attr.label(
             doc = "A file containing extra contents to write to the bottom of generated BUILD files.",
         ),
@@ -936,24 +952,12 @@ _annotation = tag_class(
         # "alias_rule": attr.string(
         #     doc = "Alias rule to use instead of `native.alias()`.  Overrides [render_config](#render_config)'s 'default_alias_rule'.",
         # ),
-        "build_script_data": attr.label_list(
-            doc = "A list of labels to add to a crate's `cargo_build_script::data` attribute.",
-        ),
         # "build_script_data_glob": attr.string_list(
         #     doc = "A list of glob patterns to add to a crate's `cargo_build_script::data` attribute",
         # ),
-        "build_script_data_select": _label_list_dict(
-            doc = "Labels to add to a crate's `cargo_build_script::data` attribute, keyed by platform triplet.",
-        ),
         # "build_script_deps": attr.label_list(
         #     doc = "A list of labels to add to a crate's `cargo_build_script::deps` attribute.",
         # ),
-        "build_script_env": attr.string_dict(
-            doc = "Additional environment variables to set on a crate's `cargo_build_script::env` attribute.",
-        ),
-        "build_script_env_select": attr.string_dict(
-            doc = "Additional environment variables to set on a crate's `cargo_build_script::env` attribute. Key should be the platform triplet. Value should be a JSON encoded dictionary mapping variable names to values, for example `{\"FOO\": \"bar\"}`.",
-        ),
         "build_script_env_files": attr.label_list(
             doc = "Files containing additional environment variables for a crate's `cargo_build_script`.",
             allow_files = True,
@@ -977,12 +981,6 @@ _annotation = tag_class(
         "build_script_tags": attr.string_list(
             doc = "A list of tags to add to a crate's `cargo_build_script` target.",
         ),
-        "build_script_tools": attr.label_list(
-            doc = "A list of labels to add to a crate's `cargo_build_script::tools` attribute.",
-        ),
-        "build_script_tools_select": _label_list_dict(
-            doc = "Labels to add to a crate's `cargo_build_script::tools` attribute, keyed by platform triplet.",
-        ),
         # "compile_data": attr.label_list(
         # doc = "A list of labels to add to a crate's `rust_library::compile_data` attribute.",
         # ),
@@ -992,12 +990,6 @@ _annotation = tag_class(
         # "compile_data_glob_excludes": attr.string_list(
         # doc = "A list of glob patterns to be excllued from a crate's `rust_library::compile_data` attribute.",
         # ),
-        "crate_features": attr.string_list(
-            doc = "A list of strings to add to a crate's `rust_library::crate_features` attribute.",
-        ),
-        "crate_features_select": attr.string_list_dict(
-            doc = "A list of strings to add to a crate's `rust_library::crate_features` attribute. Keys should be the platform triplet. Value should be a list of features.",
-        ),
         "data": attr.label_list(
             doc = "A list of labels to add to a crate's `rust_library::data` attribute.",
         ),
@@ -1057,12 +1049,6 @@ _annotation = tag_class(
         # "rustc_env_files": attr.label_list(
         #     doc = "A list of labels to set on a crate's `rust_library::rustc_env_files` attribute.",
         # ),
-        "rustc_flags": attr.string_list(
-            doc = "A list of strings to set on a crate's `rust_library::rustc_flags` attribute.",
-        ),
-        "rustc_flags_select": attr.string_list_dict(
-            doc = "A list of strings to set on a crate's `rust_library::rustc_flags` attribute. Keys should be the platform triplet. Value should be a list of flags.",
-        ),
         # "shallow_since": attr.string(
         #     doc = "An optional timestamp used for crates originating from a git repository instead of a crate registry. This flag optimizes fetching the source code.",
         # ),
@@ -1074,10 +1060,21 @@ _annotation = tag_class(
     },
 )
 
+_annotation_select = tag_class(
+    doc = "A collection of build attributes applied to a crate for selected platform triples. Source attributes such as patches and workspace_cargo_toml belong on crate.annotation.",
+    attrs = _ANNOTATION_COMMON_ATTRS | {
+        "triples": attr.string_list(
+            doc = "Platform triples to which the annotation applies.",
+            mandatory = True,
+        ),
+    } | _ANNOTATION_SELECTABLE_ATTRS,
+)
+
 crate = module_extension(
     implementation = _crate_impl,
     tag_classes = {
         "annotation": _annotation,
+        "annotation_select": _annotation_select,
         "config": _config,
         "from_cargo": _from_cargo,
     },

--- a/rs/private/BUILD.bazel
+++ b/rs/private/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 load("@rules_rust//rust:rust_stdlib_filegroup.bzl", "rust_stdlib_filegroup")
 load(":all_crate_deps_test.bzl", "all_crate_deps_tests")
+load(":annotations_test.bzl", "annotations_tests")
 load(":bindgen_test.bzl", "bindgen_tests")
 load(":bpf_linker_repository_test.bzl", "bpf_linker_repository_tests")
 load(":cargo_toml_utils_test.bzl", "cargo_toml_utils_tests")
@@ -25,6 +26,8 @@ rust_stdlib_filegroup(
 )
 
 all_crate_deps_tests()
+
+annotations_tests()
 
 bindgen_tests()
 
@@ -354,6 +357,16 @@ bzl_library(
     name = "annotations",
     srcs = ["annotations.bzl"],
     visibility = ["//rs:__subpackages__"],
+    deps = ["@bazel_skylib//lib:structs"],
+)
+
+bzl_library(
+    name = "annotations_test",
+    srcs = ["annotations_test.bzl"],
+    deps = [
+        ":annotations",
+        "@bazel_skylib//lib:unittest",
+    ],
 )
 
 bzl_library(

--- a/rs/private/annotations.bzl
+++ b/rs/private/annotations.bzl
@@ -1,3 +1,5 @@
+load("@bazel_skylib//lib:structs.bzl", "structs")
+
 def _crate_annotation(
         additive_build_file = None,
         additive_build_file_content = "",
@@ -93,24 +95,159 @@ def annotation_for(annotations_by_crate, crate_name, version, hub_name):
     version_map = annotations_by_crate.get(crate_name, {})
     annotation = version_map.get(version) or version_map.get("*")
     if annotation:
+        if crate_name in _WINDOWS_GNULLVM_CRATES:
+            implicit = _windows_gnullvm_implicit_annotation(crate_name, version, hub_name)
+            values = structs.to_dict(implicit)
+            defaults = structs.to_dict(_DEFAULT_CRATE_ANNOTATION)
+            for field, value in structs.to_dict(annotation).items():
+                # Tag-class string attributes use "" where the internal
+                # annotation representation uses None.
+                if value == defaults.get(field) or (value == "" and defaults.get(field) == None):
+                    continue
+                if field == "deps":
+                    values[field] += value
+                elif field == "extra_aliased_targets":
+                    values[field].update(value)
+                elif field == "additive_build_file_content":
+                    values[field] += value
+                else:
+                    values[field] = value
+            return _crate_annotation(**values)
         return annotation
 
     if crate_name in _WINDOWS_GNULLVM_CRATES:
         return _windows_gnullvm_implicit_annotation(crate_name, version, hub_name)
     return _DEFAULT_CRATE_ANNOTATION
 
-def build_annotation_map(mod, cfg_name):
+_SELECTABLE_ANNOTATION_FIELDS = {
+    "build_script_data": "build_script_data_select",
+    "build_script_env": "build_script_env_select",
+    "build_script_tools": "build_script_tools_select",
+    "crate_features": "crate_features_select",
+    "rustc_flags": "rustc_flags_select",
+}
+
+_LIST_SELECT_FIELDS = [
+    select_field
+    for field, select_field in _SELECTABLE_ANNOTATION_FIELDS.items()
+    if field != "build_script_env"
+]
+
+_SELECT_MAP_FIELDS = _SELECTABLE_ANNOTATION_FIELDS.values()
+
+def _annotation_values(annotation):
+    values = structs.to_dict(annotation)
+    for field in ["crate", "repositories", "triples", "version"]:
+        values.pop(field, None)
+    return values
+
+def _merge_annotation_select(selects, annotation, crate, version, cfg_name):
+    selected_values = _annotation_values(annotation)
+    for field, select_field in _SELECTABLE_ANNOTATION_FIELDS.items():
+        value = selected_values.get(field)
+        if not value:
+            continue
+
+        # Stringify labels only after tag resolution has anchored them to the
+        # module that declared the annotation. Keep environment values as
+        # dictionaries so wildcard and exact selections can compose by key.
+        selected_value = dict(value) if field == "build_script_env" else [str(item) for item in value]
+        platform_values = dict(selects.get(select_field, {}))
+        for triple in annotation.triples:
+            if triple in platform_values:
+                fail("Duplicate crate.annotation_select for %s version %s triple %s field %s in repo %s" % (crate, version, triple, field, cfg_name))
+            platform_values[triple] = selected_value
+        selects[select_field] = platform_values
+
+def _fill_select_defaults(values, platform_triples):
+    # Keep explicitly selected values conditional, including empty branches.
+    for field in _LIST_SELECT_FIELDS:
+        platform_values = values.get(field)
+        if not platform_values:
+            continue
+
+        platform_values = dict(platform_values)
+        for triple in platform_triples:
+            platform_values.setdefault(triple, [])
+        values[field] = platform_values
+
+def _merge_select_maps(base, override):
+    for field in _SELECT_MAP_FIELDS:
+        if field not in override:
+            continue
+        selected = dict(base.get(field, {}))
+        for triple, value in override[field].items():
+            if triple not in selected:
+                selected[triple] = value
+            elif field == "build_script_env_select":
+                merged = dict(selected[triple])
+                merged.update(value)
+                selected[triple] = merged
+            else:
+                selected[triple] = selected[triple] + value
+        base[field] = selected
+
+def _normalize_select_maps(values):
+    for field in _LIST_SELECT_FIELDS:
+        values[field] = {
+            triple: [str(item) for item in items]
+            for triple, items in values.get(field, {}).items()
+        }
+    values["build_script_env_select"] = {
+        triple: json.decode(env) if type(env) == "string" else dict(env)
+        for triple, env in values.get("build_script_env_select", {}).items()
+    }
+
+def _encode_env_select(values):
+    values["build_script_env_select"] = {
+        triple: json.encode(env)
+        for triple, env in values.get("build_script_env_select", {}).items()
+    }
+
+def _annotation_entry():
+    return {
+        "annotation": None,
+        "selects": {},
+    }
+
+def build_annotation_map(mod, cfg_name, platform_triples):
     """Build mapping {crate: {version|\"*\": annotation}} for a cfg name."""
     annotations = {}
     for annotation in mod.tags.annotation:
-        if cfg_name not in (annotation.repositories or [cfg_name]):
+        if annotation.repositories and cfg_name not in annotation.repositories:
             continue
 
         version_key = annotation.version or "*"
         crate_map = annotations.setdefault(annotation.crate, {})
-        if version_key in crate_map:
+        entry = crate_map.setdefault(version_key, _annotation_entry())
+        if entry["annotation"] != None:
             fail("Duplicate crate.annotation for %s version %s in repo %s" % (annotation.crate, version_key, cfg_name))
-        crate_map[version_key] = annotation
+        entry["annotation"] = _annotation_values(annotation)
+
+    for annotation in mod.tags.annotation_select:
+        if annotation.repositories and cfg_name not in annotation.repositories:
+            continue
+
+        version_key = annotation.version or "*"
+        crate_map = annotations.setdefault(annotation.crate, {})
+        entry = crate_map.setdefault(version_key, _annotation_entry())
+        _merge_annotation_select(entry["selects"], annotation, annotation.crate, version_key, cfg_name)
+
+    for crate_map in annotations.values():
+        wildcard_entry = crate_map.get("*")
+        wildcard_annotation = wildcard_entry["annotation"] if wildcard_entry else None
+        wildcard_selects = wildcard_entry["selects"] if wildcard_entry else {}
+        for version, entry in crate_map.items():
+            values = dict(entry["annotation"] or wildcard_annotation or structs.to_dict(_DEFAULT_CRATE_ANNOTATION))
+            _normalize_select_maps(values)
+            selects = {}
+            _merge_select_maps(selects, wildcard_selects)
+            if version != "*":
+                _merge_select_maps(selects, entry["selects"])
+            _merge_select_maps(values, selects)
+            _fill_select_defaults(values, platform_triples)
+            _encode_env_select(values)
+            crate_map[version] = _crate_annotation(**values)
     return annotations
 
 def well_known_annotation_snippet_paths(mctx):

--- a/rs/private/annotations_test.bzl
+++ b/rs/private/annotations_test.bzl
@@ -1,0 +1,213 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":annotations.bzl", "annotation_for", "build_annotation_map")
+
+_TRIPLES = [
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+]
+
+def _mod(annotations = [], annotation_selects = []):
+    return struct(
+        tags = struct(
+            annotation = annotations,
+            annotation_select = annotation_selects,
+        ),
+    )
+
+_ANNOTATION_DEFAULTS = {
+    "additive_build_file": None,
+    "additive_build_file_content": "",
+    "allow_build_script_to_detect_nonhermetic_paths": False,
+    "build_script_data": [],
+    "build_script_env": {},
+    "build_script_env_files": [],
+    "build_script_tags": [],
+    "build_script_toolchains": [],
+    "build_script_tools": [],
+    "crate_features": [],
+    "data": [],
+    "deps": [],
+    "extra_aliased_targets": {},
+    "gen_binaries": [],
+    "gen_build_script": "auto",
+    "link_deps": [],
+    "patch_args": [],
+    "patch_tool": "",
+    "patches": [],
+    "rustc_flags": [],
+    "strip_prefix": "",
+    "tags": [],
+    "workspace_cargo_toml": "Cargo.toml",
+}
+
+_ANNOTATION_SELECT_DEFAULTS = {
+    "build_script_data": [],
+    "build_script_env": {},
+    "build_script_tools": [],
+    "crate_features": [],
+    "rustc_flags": [],
+}
+
+def _annotation(crate, version = "*", **kwargs):
+    values = dict(_ANNOTATION_DEFAULTS)
+    values.update(kwargs)
+    return struct(crate = crate, repositories = [], version = version, **values)
+
+def _annotation_select(crate, triples, version = "*", **kwargs):
+    values = dict(_ANNOTATION_SELECT_DEFAULTS)
+    values.update(kwargs)
+    return struct(crate = crate, repositories = [], triples = triples, version = version, **values)
+
+def _exact_annotation_replaces_wildcard_and_composes_with_select_impl(ctx):
+    env = unittest.begin(ctx)
+    annotations = build_annotation_map(
+        _mod(
+            annotations = [
+                _annotation(
+                    "example",
+                    gen_build_script = "on",
+                    link_deps = ["//:wildcard_link_dep"],
+                    patches = ["//:wildcard.patch"],
+                    workspace_cargo_toml = "crate/Cargo.toml",
+                ),
+                _annotation(
+                    "example",
+                    version = "1.0.0",
+                    link_deps = ["//:exact_link_dep"],
+                    patches = ["//:exact.patch"],
+                ),
+            ],
+            annotation_selects = [
+                _annotation_select(
+                    "example",
+                    ["x86_64-unknown-linux-gnu"],
+                    version = "1.0.0",
+                    rustc_flags = ["--cfg=exact"],
+                ),
+            ],
+        ),
+        "repo",
+        _TRIPLES,
+    )
+
+    annotation = annotation_for(annotations, "example", "1.0.0", "repo")
+    asserts.equals(env, "auto", annotation.gen_build_script)
+    asserts.equals(env, ["//:exact_link_dep"], annotation.link_deps)
+    asserts.equals(env, ["//:exact.patch"], annotation.patches)
+    asserts.equals(env, "Cargo.toml", annotation.workspace_cargo_toml)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["--cfg=exact"],
+    }, annotation.rustc_flags_select)
+
+    return unittest.end(env)
+
+def _wildcard_and_exact_select_payloads_compose_impl(ctx):
+    env = unittest.begin(ctx)
+    annotations = build_annotation_map(
+        _mod(
+            annotation_selects = [
+                _annotation_select(
+                    "example",
+                    ["x86_64-unknown-linux-gnu"],
+                    build_script_env = {"COMMON": "wildcard", "OVERRIDE": "wildcard"},
+                    rustc_flags = ["--cfg=wildcard"],
+                ),
+                _annotation_select(
+                    "example",
+                    ["x86_64-unknown-linux-gnu"],
+                    version = "1.0.0",
+                    build_script_env = {"EXACT": "exact", "OVERRIDE": "exact"},
+                    rustc_flags = ["--cfg=exact"],
+                ),
+            ],
+        ),
+        "repo",
+        _TRIPLES,
+    )
+
+    annotation = annotation_for(annotations, "example", "1.0.0", "repo")
+    asserts.equals(env, {
+        "COMMON": "wildcard",
+        "EXACT": "exact",
+        "OVERRIDE": "exact",
+    }, json.decode(annotation.build_script_env_select["x86_64-unknown-linux-gnu"]))
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["--cfg=wildcard", "--cfg=exact"],
+    }, annotation.rustc_flags_select)
+
+    return unittest.end(env)
+
+def _wildcard_select_composes_with_exact_annotation_impl(ctx):
+    env = unittest.begin(ctx)
+    annotations = build_annotation_map(
+        _mod(
+            annotations = [
+                _annotation(
+                    "example",
+                    version = "1.0.0",
+                    patches = ["//:exact.patch"],
+                ),
+            ],
+            annotation_selects = [
+                _annotation_select(
+                    "example",
+                    ["x86_64-unknown-linux-gnu"],
+                    rustc_flags = ["--cfg=wildcard"],
+                ),
+            ],
+        ),
+        "repo",
+        _TRIPLES,
+    )
+
+    annotation = annotation_for(annotations, "example", "1.0.0", "repo")
+    asserts.equals(env, ["//:exact.patch"], annotation.patches)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["--cfg=wildcard"],
+    }, annotation.rustc_flags_select)
+
+    return unittest.end(env)
+
+def _selected_windows_gnullvm_annotation_keeps_implicit_values_impl(ctx):
+    env = unittest.begin(ctx)
+    annotations = build_annotation_map(
+        _mod(
+            annotation_selects = [
+                _annotation_select(
+                    "windows_x86_64_gnullvm",
+                    ["x86_64-unknown-linux-gnu"],
+                    rustc_flags = ["--cfg=selected"],
+                ),
+            ],
+        ),
+        "repo",
+        _TRIPLES,
+    )
+
+    annotation = annotation_for(annotations, "windows_x86_64_gnullvm", "0.53.0", "repo")
+    asserts.equals(env, "off", annotation.gen_build_script)
+    asserts.equals(env, ["@repo//:windows_x86_64_gnullvm_import_lib-0.53.0"], annotation.deps)
+    asserts.equals(env, {"windows_x86_64_gnullvm_import_lib": "windows_import_lib"}, annotation.extra_aliased_targets)
+    asserts.equals(env, {
+        "aarch64-apple-darwin": [],
+        "x86_64-unknown-linux-gnu": ["--cfg=selected"],
+    }, annotation.rustc_flags_select)
+
+    return unittest.end(env)
+
+exact_annotation_replaces_wildcard_and_composes_with_select_test = unittest.make(_exact_annotation_replaces_wildcard_and_composes_with_select_impl)
+wildcard_and_exact_select_payloads_compose_test = unittest.make(_wildcard_and_exact_select_payloads_compose_impl)
+wildcard_select_composes_with_exact_annotation_test = unittest.make(_wildcard_select_composes_with_exact_annotation_impl)
+selected_windows_gnullvm_annotation_keeps_implicit_values_test = unittest.make(_selected_windows_gnullvm_annotation_keeps_implicit_values_impl)
+
+def annotations_tests():
+    return unittest.suite(
+        "annotations_tests",
+        exact_annotation_replaces_wildcard_and_composes_with_select_test,
+        wildcard_and_exact_select_payloads_compose_test,
+        wildcard_select_composes_with_exact_annotation_test,
+        selected_windows_gnullvm_annotation_keeps_implicit_values_test,
+    )

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -182,30 +182,36 @@ crate.annotation(
     crate = "rustls",
     # Test for https://github.com/bazelbuild/rules_rust/issues/3626
     crate_features = ["fips"],
-    crate_features_select = {
-        "x86_64-unknown-linux-gnu": ["fips"],
-    },
     repositories = ["annotation_crate_features"],
-    rustc_flags_select = {
-        "x86_64-unknown-linux-gnu": ["--cfg=rules_rs_annotation_smoke"],
-    },
 )
-crate.annotation(
+crate.annotation_select(
+    crate = "rustls",
+    crate_features = ["fips"],
+    repositories = ["annotation_crate_features"],
+    rustc_flags = ["--cfg=rules_rs_annotation_smoke"],
+    triples = ["x86_64-unknown-linux-gnu"],
+)
+crate.annotation_select(
+    build_script_data = ["//:main.rs"],
+    build_script_env = {"OS": "darwin"},
+    build_script_tools = ["//:main.rs"],
     # Smoke test the select attributes.
-    build_script_data_select = {
-        "aarch64-apple-darwin": ["//:main.rs"],
-        "x86_64-unknown-linux-gnu": ["//:dummy_test.sh"],
-    },
-    build_script_env_select = {
-        "aarch64-apple-darwin": '{"OS": "darwin"}',
-        "x86_64-unknown-linux-musl": '{"OS": "linux"}',
-    },
-    build_script_tools_select = {
-        "aarch64-apple-darwin": ["//:main.rs"],
-        "x86_64-unknown-linux-gnu": ["//:dummy_test.sh"],
-    },
     crate = "bitflags",
     repositories = ["build_script_env_select"],
+    triples = ["aarch64-apple-darwin"],
+)
+crate.annotation_select(
+    build_script_data = ["//:dummy_test.sh"],
+    build_script_tools = ["//:dummy_test.sh"],
+    crate = "bitflags",
+    repositories = ["build_script_env_select"],
+    triples = ["x86_64-unknown-linux-gnu"],
+)
+crate.annotation_select(
+    build_script_env = {"OS": "linux"},
+    crate = "bitflags",
+    repositories = ["build_script_env_select"],
+    triples = ["x86_64-unknown-linux-musl"],
 )
 crate.annotation(
     crate = "tokenizers",


### PR DESCRIPTION
## Summary

- Add `crate.annotation_select` for platform-specific build-script inputs and environment, crate features, and Rust compiler flags.
- Compose wildcard and exact-version selected payloads while preserving the existing exact-over-wildcard precedence for normal `crate.annotation` settings.
- Keep platform selection exclusively on `crate.annotation_select`; the normal annotation no longer exposes the corresponding `*_select` attributes.
- Preserve implicit Windows `gnullvm` annotations.
- Keep dependencies, link dependencies, and source-level settings on `crate.annotation`; they remain non-selectable.
- Migrate the smoke fixtures and add focused annotation-normalization and merging tests.

## Testing

- `bazel test //...`
- `cd test && bazel build @build_script_env_select//:bitflags-2.9.4`