### PR TITLE
feat: expose rust_test_suite

### DIFF
--- a/rs/BUILD.bazel
+++ b/rs/BUILD.bazel
@@ -141,6 +141,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "rust_test_suite",
+    srcs = ["rust_test_suite.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_features//:features",
+        "@rules_rust//rust:bzl_lib",
+    ],
+)
+
+bzl_library(
     name = "rust_shared_library",
     srcs = ["rust_shared_library.bzl"],
     visibility = ["//visibility:public"],

--- a/rs/rust_test_suite.bzl
+++ b/rs/rust_test_suite.bzl
@@ -1,0 +1,3 @@
+load("@rules_rust//rust:defs.bzl", _rust_test_suite = "rust_test_suite")
+
+rust_test_suite = _rust_test_suite

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load("@rules_rs//rs:rust_test_suite.bzl", "rust_test_suite")
 load("@rules_rust//rust:defs.bzl", "rust_doc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@self_dev_dependency//:data.bzl", self_dev_dependency_dep_data = "DEP_DATA")
@@ -17,6 +18,14 @@ load("//:target_triple_constraints_test.bzl", "target_triple_constraints_test")
 load("//:verify_aliases.bzl", "verify_alias", "verify_alias_absent", "verify_crate_feature_absent", "verify_crate_feature_present", "verify_dep_absent", "verify_dep_present", "verify_dev_dep_absent")
 
 target_triple_constraints_test()
+
+rust_test_suite(
+    name = "rust_test_suite",
+    srcs = [
+        "rust_test_suite_a.rs",
+        "rust_test_suite_b.rs",
+    ],
+)
 
 sh_test(
     name = "custom_registry_test",

--- a/test/rust_test_suite_a.rs
+++ b/test/rust_test_suite_a.rs
@@ -1,0 +1,4 @@
+#[test]
+fn suite_test_a() {
+    assert_eq!(2 + 2, 4);
+}

--- a/test/rust_test_suite_b.rs
+++ b/test/rust_test_suite_b.rs
@@ -1,0 +1,4 @@
+#[test]
+fn suite_test_b() {
+    assert_eq!(3 * 3, 9);
+}


### PR DESCRIPTION
## Summary

- expose the upstream `rust_test_suite` macro through a public `rules_rs` wrapper
- add the generated `bzl_library` target
- exercise the wrapper with two generated Rust test targets

## Why

`rules_rs` recommends loading Rust rules through its facade, but users currently need to load `rust_test_suite` directly from `@rules_rust`. This adds API parity with the pinned upstream ruleset and makes migration and consistent loading simpler.

## Validation

- `buildifier rs/rust_test_suite.bzl rs/BUILD.bazel test/BUILD.bazel`
- `bazel test //:rust_test_suite` from the `test` workspace (2 tests passed)
- `git diff --cached --check`